### PR TITLE
Rename `Build` step to `Build / Test`

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -58,5 +58,5 @@ jobs:
           done
     - name: Pre-build
       run: ${{ inputs.pre_build_command }}
-    - name: Build
+    - name: Build / Test
       run: ${{ inputs.build_command }} ${{ (contains(matrix.swift_version, 'nightly') && inputs.swift_nightly_flags) || inputs.swift_flags }}


### PR DESCRIPTION
The `Build` step usually also runs tests. Rename the step’s name to reflect that.