### PR TITLE
Increase default format check job timeout

### DIFF
--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: swiftlang/swift:nightly-6.0-jammy
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4


### PR DESCRIPTION
Seems that the 5 minutes are not enough frequently, esp. since this step includes installing curl.