### PR TITLE
Fix the version of swift-format being used in format check

### DIFF
--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -143,7 +143,7 @@ jobs:
     if: ${{ inputs.format_check_enabled }}
     runs-on: ubuntu-latest
     container:
-      image: swiftlang/swift:nightly-6.0-jammy
+      image: swift:6.0-jammy
     timeout-minutes: 10
     steps:
     - name: Checkout repository


### PR DESCRIPTION
I think we should pin down one specific version of swift-format to be used in the format check to avoid CI failures if swift-format changes.