### PR TITLE
Remove `--break-system-packages` from Python lint job

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
+    uses: ./.github/workflows/soundness.yml
     with:
       api_breakage_check_enabled: false
       license_header_check_enabled: false

--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -216,6 +216,6 @@ jobs:
           persist-credentials: false
       - name: Run flake8
         run: |
-          pip3 install flake8 flake8-import-order --break-system-packages
+          pip3 install flake8 flake8-import-order
           cd ${GITHUB_WORKSPACE}
           flake8


### PR DESCRIPTION
`--break-system-packages` was only needed when we ran in a Swift container and is an unknown option when running directly on the GitHub action runner.

Also change the pull request workflow on this repo to use the workflows they are modified by PRs, not as they are defined on `main` before the PR was applied. This would have caught the Python-lint issue and allows me to unbreak it.