### PR TITLE
Ignore some python formatting errors for licenses

### DIFF
--- a/.github/workflows/configs/.flake8
+++ b/.github/workflows/configs/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+
+ignore =
+    # These are needed to make our license headers pass the linting
+    E265,
+    E266,
+
+# 10% larger than the standard 80 character limit. Conforms to the black
+# standard and Bugbear's B950.
+max-line-length = 88

--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -218,4 +218,8 @@ jobs:
         run: |
           pip3 install flake8 flake8-import-order
           cd ${GITHUB_WORKSPACE}
+          if [ ! -f ".flake8" ]; then
+            echo "Downloading default flake8 config file"
+            curl -s https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/configs/.flake8.yml > .flake8
+          fi
           flake8

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2020 Apple Inc. and the Swift.org project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of Swift.org project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##


### PR DESCRIPTION
# Motivation

We want to lint our python files but also need to include our license header.

# Modification

This PR ignores a few python flake rules to make sure the license headers pass.

# Result

Passing license headers.