### PR TITLE
Add optional unacceptable language ignore file

### DIFF
--- a/.github/workflows/scripts/check-unacceptable-language.sh
+++ b/.github/workflows/scripts/check-unacceptable-language.sh
@@ -19,17 +19,21 @@ fatal() { error "$@"; exit 1; }
 
 test -n "${UNACCEPTABLE_WORD_LIST:-}" || fatal "UNACCEPTABLE_WORD_LIST unset"
 
-log "Checking for unacceptable language..."
-unacceptable_language_lines=$(git grep \
-  -i -I -w \
-  -H -n --column \
-  -E "${UNACCEPTABLE_WORD_LIST// /|}" | grep -v "ignore-unacceptable-language"
-) || true | /usr/bin/paste -s -d " " -
+unacceptable_language_lines=
+if [[ -f .unacceptablelanguageignore ]]; then
+    log "Found for unacceptable file..."
+    log "Checking for unacceptable language..."
+    unacceptable_language_lines=$(tr '\n' '\0' < .unacceptablelanguageignore | xargs -0 -I% printf '":(exclude)%" '| xargs git grep -i -I -w -H -n --column -E "${UNACCEPTABLE_WORD_LIST// /|}" | grep -v "ignore-unacceptable-language") || true | /usr/bin/paste -s -d " " -
+else
+    log "Checking for unacceptable language..."
+    unacceptable_language_lines=$(git grep -i -I -w -H -n --column -E "${UNACCEPTABLE_WORD_LIST// /|}" | grep -v "ignore-unacceptable-language") || true | /usr/bin/paste -s -d " " -
+fi
 
 if [ -n "${unacceptable_language_lines}" ]; then
     fatal " ❌ Found unacceptable language:
 ${unacceptable_language_lines}
 "
 fi
+
 
 log "✅ Found no unacceptable language."


### PR DESCRIPTION
Some of our repos contain code that is pulled in from third parties such as swift-crypto that vendors boringssl. This code can contain unacceptable language. We cannot disable this currently since the only way to do this is by adding comments.

To support such use-cases this PR extends the unacceptable-language script to also look for an optional `.unacceptablelanguageignore` file at the root of the repo.