### PR TITLE
Silently ignore .licenseignore and .license_header_template

### DIFF
--- a/.github/workflows/scripts/check-license-header.sh
+++ b/.github/workflows/scripts/check-license-header.sh
@@ -40,7 +40,12 @@ fi
 
 paths_with_missing_license=( )
 
-file_paths=$(tr '\n' '\0' < .licenseignore | xargs -0 -I% printf '":(exclude)%" '| xargs git ls-files)
+file_excludes=".license_header_template
+.licenseignore"
+if [ -f .licenseignore ]; then 
+  file_excludes=$file_excludes\n$(cat .licenseignore)
+fi
+file_paths=$(echo "$file_excludes" | tr '\n' '\0' | xargs -0 -I% printf '":(exclude)%" '| xargs git ls-files)
 
 while IFS= read -r file_path; do
   file_basename=$(basename -- "${file_path}")

--- a/.github/workflows/scripts/check-license-header.sh
+++ b/.github/workflows/scripts/check-license-header.sh
@@ -43,7 +43,7 @@ paths_with_missing_license=( )
 file_excludes=".license_header_template
 .licenseignore"
 if [ -f .licenseignore ]; then 
-  file_excludes=$file_excludes\n$(cat .licenseignore)
+  file_excludes=$file_excludes$(printf '\n')$(cat .licenseignore)
 fi
 file_paths=$(echo "$file_excludes" | tr '\n' '\0' | xargs -0 -I% printf '":(exclude)%" '| xargs git ls-files)
 


### PR DESCRIPTION
The recent change (https://github.com/swiftlang/github-workflows/commit/6aa8cf2bdca71d9600431979392c2c2496f3075e) in `check-license-header.sh` breaks CI in projects that don't have a `.license_header_template` file.

Project owners could add `.license_header_template` to their `.licenseignore` file but this is manual work from each project owner.

This change avoids project owners to make change. It silently ignores `.licenseignore` and `.license_header_template` files