### PR TITLE
Fix license header check ignoring well known files

### DIFF
--- a/.github/workflows/scripts/check-broken-symlinks.sh
+++ b/.github/workflows/scripts/check-broken-symlinks.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-# ===----------------------------------------------------------------------===//
-#
-# This source file is part of the Swift.org open source project
-#
-# Copyright (c) 2024 Apple Inc. and the Swift project authors
-# Licensed under Apache License v2.0 with Runtime Library Exception
-#
-# See https://swift.org/LICENSE.txt for license information
-# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-#
-# ===----------------------------------------------------------------------===//
+## ===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+## See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+##
+## ===----------------------------------------------------------------------===##
 
 set -euo pipefail
 

--- a/.github/workflows/scripts/check-docs.sh
+++ b/.github/workflows/scripts/check-docs.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-# ===----------------------------------------------------------------------===//
-#
-# This source file is part of the Swift.org open source project
-#
-# Copyright (c) 2024 Apple Inc. and the Swift project authors
-# Licensed under Apache License v2.0 with Runtime Library Exception
-#
-# See https://swift.org/LICENSE.txt for license information
-# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-#
-# ===----------------------------------------------------------------------===//
+## ===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+## See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+##
+## ===----------------------------------------------------------------------===##
 
 set -euo pipefail
 

--- a/.github/workflows/scripts/check-license-header.sh
+++ b/.github/workflows/scripts/check-license-header.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-# ===----------------------------------------------------------------------===//
-#
-# This source file is part of the Swift.org open source project
-#
-# Copyright (c) 2024 Apple Inc. and the Swift project authors
-# Licensed under Apache License v2.0 with Runtime Library Exception
-#
-# See https://swift.org/LICENSE.txt for license information
-# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-#
-# ===----------------------------------------------------------------------===//
+## ===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+## See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+##
+## ===----------------------------------------------------------------------===##
 
 set -euo pipefail
 
@@ -40,12 +40,12 @@ fi
 
 paths_with_missing_license=( )
 
-file_excludes=".license_header_template
-.licenseignore"
-if [ -f .licenseignore ]; then 
-  file_excludes=$file_excludes$(printf '\n')$(cat .licenseignore)
+if [[ -f .licenseignore ]]; then
+  file_paths=$(tr '\n' '\0' < .licenseignore | xargs -0 -I% printf '":(exclude)%" '| xargs git ls-files ":(exclude).licenseignore" ":(exclude).license_header_template" )
+else
+  file_paths=$(git ls-files ":(exclude).license_header_template" )
 fi
-file_paths=$(echo "$file_excludes" | tr '\n' '\0' | xargs -0 -I% printf '":(exclude)%" '| xargs git ls-files)
+
 
 while IFS= read -r file_path; do
   file_basename=$(basename -- "${file_path}")

--- a/.github/workflows/scripts/check-swift-format.sh
+++ b/.github/workflows/scripts/check-swift-format.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-# ===----------------------------------------------------------------------===//
-#
-# This source file is part of the Swift.org open source project
-#
-# Copyright (c) 2024 Apple Inc. and the Swift project authors
-# Licensed under Apache License v2.0 with Runtime Library Exception
-#
-# See https://swift.org/LICENSE.txt for license information
-# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-#
-# ===----------------------------------------------------------------------===//
+## ===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+## See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+##
+## ===----------------------------------------------------------------------===##
 
 set -euo pipefail
 

--- a/.github/workflows/scripts/check-unacceptable-language.sh
+++ b/.github/workflows/scripts/check-unacceptable-language.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-# ===----------------------------------------------------------------------===//
-#
-# This source file is part of the Swift.org open source project
-#
-# Copyright (c) 2024 Apple Inc. and the Swift project authors
-# Licensed under Apache License v2.0 with Runtime Library Exception
-#
-# See https://swift.org/LICENSE.txt for license information
-# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-#
-# ===----------------------------------------------------------------------===//
+## ===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+## See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+##
+## ===----------------------------------------------------------------------===##
 
 set -euo pipefail
 

--- a/.license_header_template
+++ b/.license_header_template
@@ -1,9 +1,8 @@
-#!/usr/bin/env python3
 ## ===----------------------------------------------------------------------===##
 ##
 ## This source file is part of the Swift.org open source project
 ##
-## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Copyright (c) YEARS Apple Inc. and the Swift project authors
 ## Licensed under Apache License v2.0 with Runtime Library Exception
 ##
 ## See https://swift.org/LICENSE.txt for license information

--- a/.licenseignore
+++ b/.licenseignore
@@ -1,0 +1,5 @@
+.github/workflows/configs/.flake8
+**/*.yml
+CODEOWNERS
+LICENSE.txt
+README.md


### PR DESCRIPTION
The previous PR tried to ignore two well known files `.licenseignore` and `.license_header_template`. However, that PR wasn't fully working and broke this check.

This PR fixes it by using a slightly different approach for those well known files.