### PR TITLE
Install yamllint if missing.

### DIFF
--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -202,6 +202,7 @@ jobs:
           persist-credentials: false
       - name: Run yamllint
         run: |
+          which yamllint >/dev/null || ( apt-get update && apt-get install -y yamllint )
           curl -s https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/configs/yamllint.yml > /tmp/yamllint.yml
           yamllint --strict --config-file /tmp/yamllint.yml ${GITHUB_WORKSPACE}
   python-lint-check:


### PR DESCRIPTION
Motivation:

Real github actions hosts have yamllint pre-installed. Docker images through act by default don't.
This leads to an annoying workflow for local runs.

Modifications:

Install yamllint if not found.

Result:

Both local and hosted github actions should work without modification.