### PR TITLE
Propagate errors from the Windows run script

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -37,7 +37,10 @@ on:
         default: ""
       windows_build_command:
         type: string
-        description: "Windows Command Prompt command to build and test the package"
+        description: |
+          Windows Command Prompt command to build and test the package.
+          Note that Powershell does not automatically exit if a subcommand fails. The Invoke-Program utility is available to propagate non-zero exit codes.
+          It is strongly encouraged to run all command using `Invoke-Program` unless you want to continue on error eg. `Invoke-Program git apply patch.diff` instead of `git apply patch.diff`.
         default: "swift test"
       linux_env_vars:
         description: "List of environment variables"
@@ -84,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift_version: ['5.9', '5.10', '6.0', 'nightly', 'nightly-6.0']
+        swift_version: ['5.9', '6.0', 'nightly', 'nightly-6.0']
         exclude:
           - ${{ fromJson(inputs.windows_exclude_swift_versions) }}
     steps:
@@ -103,15 +106,23 @@ jobs:
       - name: Create test script
         run: |
           mkdir $env:TEMP\test-script
-          echo 'Set-PSDebug -Trace 1' >> $env:TEMP\test-script\run.ps1
-          echo '$ErrorActionPreference = "Stop"' >> $env:TEMP\test-script\run.ps1
-          echo 'swift --version' >> $env:TEMP\test-script\run.ps1
-          echo 'swift test --version' >> $env:TEMP\test-script\run.ps1
-          echo 'cd C:\source\' >> $env:TEMP\test-script\run.ps1
           echo @'
+          Set-PSDebug -Trace 1
+
+          # Run the command following `Invoke-Program`.
+          # If that command returns a non-zero exit code, return the same exit code from this script.
+          function Invoke-Program($Executable) {
+            & $Executable @args
+            if ($LastExitCode -ne 0) {
+              exit $LastExitCode
+            }
+          }
+          Invoke-Program swift --version
+          Invoke-Program swift test --version
+          Invoke-Program cd C:\source\
           ${{ inputs.windows_pre_build_command }}
+          Invoke-Program ${{ inputs.windows_build_command }} ${{ (contains(matrix.swift_version, 'nightly') && inputs.swift_nightly_flags) || inputs.swift_flags }}
           '@ >> $env:TEMP\test-script\run.ps1
-          echo '${{ inputs.windows_build_command }} ${{ (contains(matrix.swift_version, 'nightly') && inputs.swift_nightly_flags) || inputs.swift_flags }}' >> $env:TEMP\test-script\run.ps1
       - name: Build / Test
         timeout-minutes: 60
         run: |


### PR DESCRIPTION
Powershell does not automatically exit if a subcommand fails, ie. it behaves similar to a Bash script without `set -e`. This means that `swift test` could fail and `run.ps1` would still return exit code 0, indicating success.

Add an `Invoke-Program` utility to `run.ps1` that propagates error codes.

Unfortunately, we need to disable Windows 5.10 again because it fails to build Swift packages with

```
Invalid manifest (compiled with: ["C:\\Users\\ContainerAdministrator\\AppData\\Local\\Programs\\Swift\\Toolchains\\5.10.1+Asserts\\usr\\bin\\swiftc.exe", "-vfsoverlay", "C:\\Users\\ContainerAdministrator\\AppData\\Local\\Temp\\TemporaryDirectory.AXNJbD\\vfs.yaml", "-L", "C:\\Users\\ContainerAdministrator\\AppData\\Local\\Programs\\Swift\\Toolchains\\5.10.1+Asserts\\usr\\lib\\swift\\pm\\ManifestAPI", "-lPackageDescription", "-sdk", "C:\\Users\\ContainerAdministrator\\AppData\\Local\\Programs\\Swift\\Platforms\\5.10.1\\Windows.platform\\Developer\\SDKs\\Windows.sdk", "-libc", "MD", "-I", "C:\\Users\\ContainerAdministrator\\AppData\\Local\\Programs\\Swift\\Platforms\\5.10.1\\Windows.platform\\Developer\\Library\\XCTest-development\\usr\\lib\\swift\\windows", "-I", "C:\\Users\\ContainerAdministrator\\AppData\\Local\\Programs\\Swift\\Platforms\\5.10.1\\Windows.platform\\Developer\\Library\\XCTest-development\\usr\\lib\\swift\\windows\\x86_64", "-L", "C:\\Users\\ContainerAdministrator\\AppData\\Local\\Programs\\Swift\\Platforms\\5.10.1\\Windows.platform\\Developer\\Library\\XCTest-development\\usr\\lib\\swift\\windows\\x86_64", "-use-ld=lld", "-swift-version", "5", "-I", "C:\\Users\\ContainerAdministrator\\AppData\\Local\\Programs\\Swift\\Toolchains\\5.10.1+Asserts\\usr\\lib\\swift\\pm\\ManifestAPI", "-package-description-version", "5.6.0", "C:\\source\\Package.swift", "-Xfrontend", "-disable-implicit-concurrency-module-import", "-Xfrontend", "-disable-implicit-string-processing-module-import", "-o", "C:\\Users\\ContainerAdministrator\\AppData\\Local\\Temp\\TemporaryDirectory.Ngb23o\\source-manifest.exe"])
Missing or empty JSON output from manifest compilation for source
```

Test run (6.0 expectedly failed here to verify): https://github.com/swiftlang/swift-format/actions/runs/11529268101/job/32097477699?pr=867