### PR TITLE
Fix job name for nightly Windows builds in Swift matrix

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -81,7 +81,7 @@ jobs:
         run: ${{ inputs.linux_build_command }} ${{ (contains(matrix.swift_version, 'nightly') && inputs.swift_nightly_flags) || inputs.swift_flags }}
 
   windows-build:
-    name: Windows (${{ matrix.swift_version }} - windows-2022)
+    name: Windows (${{ matrix.swift_version }} - ${{ contains(matrix.swift_version, 'nightly') && 'windows-2019' || 'windows-2022' }})
     if: ${{ inputs.enable_windows_checks }}
     runs-on: ${{ contains(matrix.swift_version, 'nightly') && 'windows-2019' || 'windows-2022' }}
     strategy:


### PR DESCRIPTION
Conditionalize the name of the Windows build in the same way that we conditionalize `runs-on`.