### PR TITLE
Include changes to the target branch when action is re-run

### DIFF
--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -83,6 +83,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Mark the workspace as safe
         # https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -104,6 +105,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Run documentation check
         run: |
           apt-get -qq update && apt-get -qq -y install curl yq
@@ -120,6 +122,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Run unacceptable language check
         env:
           UNACCEPTABLE_WORD_LIST: ${{ inputs.unacceptable_language_check_word_list}}
@@ -136,6 +139,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Run license header check
         env:
           PROJECT_NAME: ${{ inputs.license_header_check_project_name }}
@@ -152,6 +156,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Run broken symlinks check
         run: curl -s https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/check-broken-symlinks.sh | bash
 
@@ -168,6 +173,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Mark the workspace as safe
         # https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -189,6 +195,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Mark the workspace as safe
         # https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -208,6 +215,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Run yamllint
         run: |
           which yamllint >/dev/null || ( apt-get update && apt-get install -y yamllint )
@@ -228,6 +236,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Run flake8
         run: |
           pip3 install flake8 flake8-import-order

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -68,6 +68,8 @@ jobs:
         run: swift --version
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Set environment variables
         if: ${{ inputs.linux_env_vars }}
         run: |
@@ -93,6 +95,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Pull Docker image
         id: pull_docker_image
         run: |


### PR DESCRIPTION
When a GitHub action is re-run, it uses the same context as the original run. This means that it runs on the exact same merge commit and does not pick up changes done to the base branch since the last run.

In case the base branch is was failing when a PR was opened, this means that we can’t get CI to pass by fixing the base branch without pushing a new commit to the PR branch.

Adding `ref: ${{ github.ref }}` to the `actions/checkout` action works around this by checking out the PR merge ref (ie. `refs/pull/<pr_number>/merge`) instead of a fixed commit and the PR merge ref is updated, as described in https://github.com/actions/checkout/issues/1036.