### PR TITLE
Revert "Include changes to the target branch when action is re-run"

### DIFF
--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -83,7 +83,6 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
-          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Mark the workspace as safe
         # https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -105,7 +104,6 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
-          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Run documentation check
         run: |
           apt-get -qq update && apt-get -qq -y install curl yq
@@ -122,7 +120,6 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
-          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Run unacceptable language check
         env:
           UNACCEPTABLE_WORD_LIST: ${{ inputs.unacceptable_language_check_word_list}}
@@ -139,7 +136,6 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
-          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Run license header check
         env:
           PROJECT_NAME: ${{ inputs.license_header_check_project_name }}
@@ -156,7 +152,6 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
-          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Run broken symlinks check
         run: curl -s https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/check-broken-symlinks.sh | bash
 
@@ -173,7 +168,6 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
-          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Mark the workspace as safe
         # https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -195,7 +189,6 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
-          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Mark the workspace as safe
         # https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -215,7 +208,6 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
-          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Run yamllint
         run: |
           which yamllint >/dev/null || ( apt-get update && apt-get install -y yamllint )
@@ -236,7 +228,6 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
-          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Run flake8
         run: |
           pip3 install flake8 flake8-import-order

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -68,8 +68,6 @@ jobs:
         run: swift --version
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Set environment variables
         if: ${{ inputs.linux_env_vars }}
         run: |
@@ -95,8 +93,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Pull Docker image
         id: pull_docker_image
         run: |


### PR DESCRIPTION
Reverts swiftlang/github-workflows#58

This has resulted in a destructive outcome for developers using `act` to run the workflows locally, which is also in our public documentation now, particularly when used with `--bind`.

This patch recreates the entire repo and force updates to a ref. It literally _deleted_ my Git repo and left me with a grafted shallow clone. It discarded all my local branches and no reflog was available.

We need to revert this one quickly.

I've verified that the revert mitigates the problem by making this change in my YAMLs locally, to the commit before this PR was merged: 

```diff
-    uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@814f5831ccc6aac159903e8db6daba726c8b62d5
```

I'm sympathetic to the motivation behind the PR but I think we should revert immediately to avoid others hitting this.