### PR TITLE
Only run checkout if not running locally with act, and update to latest merge ref

### DIFF
--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -84,6 +84,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Mark the workspace as safe
         # https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -106,6 +107,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Run documentation check
         run: |
           apt-get -qq update && apt-get -qq -y install curl yq
@@ -123,6 +125,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Run unacceptable language check
         env:
           UNACCEPTABLE_WORD_LIST: ${{ inputs.unacceptable_language_check_word_list}}
@@ -140,6 +143,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Run license header check
         env:
           PROJECT_NAME: ${{ inputs.license_header_check_project_name }}
@@ -157,6 +161,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Run broken symlinks check
         run: curl -s https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/check-broken-symlinks.sh | bash
 
@@ -174,6 +179,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Mark the workspace as safe
         # https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -196,6 +202,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Mark the workspace as safe
         # https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -216,6 +223,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Run yamllint
         run: |
           which yamllint >/dev/null || ( apt-get update && apt-get install -y yamllint )
@@ -237,6 +245,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Run flake8
         run: |
           pip3 install flake8 flake8-import-order

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -69,6 +69,8 @@ jobs:
       - name: Checkout repository
         if: env.ACT != 'true'
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Set environment variables
         if: ${{ inputs.linux_env_vars }}
         run: |
@@ -95,6 +97,8 @@ jobs:
       - name: Checkout repository
         if: env.ACT != 'true'
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}  # Include changes to the target branch when action is re-run https://github.com/actions/checkout/issues/1036
       - name: Pull Docker image
         id: pull_docker_image
         run: |


### PR DESCRIPTION
## Motivation

#58 added configuration to the `actions/checkout` step to update to the latest GitHub merge ref. This meant that rerunning a job, would also re-evaluate the merge ref, if the target branch had moved on.

It was reverted in #60 because it had some unintended and destructive consequences when run locally with `act`.

However, we'd like to restore that behaviour when running in CI.

## Modifications

- Only run the `actions/checkout@v4` step in each job if _not_ running with `act`.
- Restore commit from #58 to include changes to target branch when action is re-run.

## Result

- Behaviour from #58 restored when running in CI.
- Locally, when running with `act`, no checkout step is run at all.