### PR TITLE
Add ability to include swift versions

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -3,6 +3,10 @@ name: Swift Linux Matrix
 on:
   workflow_call:
     inputs:
+      linux_swift_versions:
+        type: string
+        description: "Include Linux Swift version list (JSON)"
+        default: "[\"5.8\", \"5.9\", \"5.10\", \"6.0\", \"nightly-main\", \"nightly-6.0\"]"
       linux_exclude_swift_versions:
         type: string
         description: "Exclude Linux Swift version list (JSON)"
@@ -11,6 +15,10 @@ on:
         type: string
         description: "Linux OS version list (JSON)"
         default: "[\"jammy\"]"
+      windows_swift_versions:
+        type: string
+        description: "Include Windows Swift version list (JSON)"
+        default: "[\"5.9\", \"6.0\", \"nightly\", \"nightly-6.0\"]"
       windows_exclude_swift_versions:
         type: string
         description: "Exclude Windows Swift version list (JSON)"
@@ -57,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift_version: ['5.8', '5.9', '5.10', '6.0', 'nightly-main', 'nightly-6.0']
+        swift_version: ${{ fromJson(inputs.linux_swift_versions) }}
         os_version: ${{ fromJson(inputs.linux_os_versions) }}
         exclude:
           - ${{ fromJson(inputs.linux_exclude_swift_versions) }}
@@ -87,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift_version: ['5.9', '6.0', 'nightly', 'nightly-6.0']
+        swift_version: ${{ fromJson(inputs.windows_swift_versions) }}
         exclude:
           - ${{ fromJson(inputs.windows_exclude_swift_versions) }}
     steps:

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -6,7 +6,7 @@ on:
       linux_swift_versions:
         type: string
         description: "Include Linux Swift version list (JSON)"
-        default: "[\"5.8\", \"5.9\", \"5.10\", \"6.0\", \"nightly-main\", \"nightly-6.0\"]"
+        default: "[ \"5.9\", \"5.10\", \"6.0\", \"6.1\", \"nightly-main\", \"nightly-6.1\"]"
       linux_exclude_swift_versions:
         type: string
         description: "Exclude Linux Swift version list (JSON)"

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -18,7 +18,7 @@ on:
       windows_swift_versions:
         type: string
         description: "Include Windows Swift version list (JSON)"
-        default: "[\"5.9\", \"6.0\", \"nightly\", \"nightly-6.0\"]"
+        default: "[\"5.9\", \"6.0\", \"6.1\", \"nightly\", \"nightly-6.1\"]"
       windows_exclude_swift_versions:
         type: string
         description: "Exclude Windows Swift version list (JSON)"


### PR DESCRIPTION
In some cases, such as swiftly, there's only one particular version of swift that is being targeted at a time. It's problematic trying to exclude all of the others in the default list, and have to adjust when the workflow gets changed, making sure to exclude any additions. Add the ability for a repo like swiftly to set the list to explicit version(s) instead of excluding everything except that one version.