### PR TITLE
Clarify check-docs.sh early-exit

### DIFF
--- a/.github/workflows/scripts/check-docs.sh
+++ b/.github/workflows/scripts/check-docs.sh
@@ -17,6 +17,11 @@ log() { printf -- "** %s\n" "$*" >&2; }
 error() { printf -- "** ERROR: %s\n" "$*" >&2; }
 fatal() { error "$@"; exit 1; }
 
+if [ ! -f .spi.yml ]; then
+  log "No '.spi.yml' found, no documentation targets to check."
+  exit 0
+fi
+
 log "Editing Package.swift..."
 cat <<EOF >> "Package.swift"
 package.dependencies.append(


### PR DESCRIPTION
In the event that there is no `.spi.yml` file, the script currently exits messily:
```
** Editing Package.swift...
** Checking documentation targets...
usage: yq [-h] [--yaml-output] [--yaml-roundtrip]
          [--yaml-output-grammar-version {1.1,1.2}] [--width WIDTH]
          [--indentless-lists] [--in-place] [--version]
          [jq_filter] [files ...]
yq: error: argument files: can't open '.spi.yml': [Errno 2] No such file or directory: '.spi.yml'
** ✅ Found no documentation issues.
```

Not having an `.spi.yml` file is perfectly valid if the repository has no defined documentation targets. This change results in the following behavior:
```
** No '.spi.yml' found, no documentation targets to check.
```