### PR TITLE
Consistently only conditionally install tools in soundness checks

### DIFF
--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -106,7 +106,7 @@ jobs:
           submodules: true
       - name: Run documentation check
         run: |
-          apt-get -qq update && apt-get -qq -y install curl yq
+          which curl yq || (apt -q update && apt -yq install curl yq)
           curl -s https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/check-docs.sh | bash
 
   unacceptable-language-check:
@@ -173,7 +173,7 @@ jobs:
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
       - name: Run format check
         run: |
-          apt-get -qq update && apt-get -qq -y install curl
+          which curl || (apt -q update && apt -yq install curl)
           curl -s https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/check-swift-format.sh | bash
 
   shell-check:
@@ -194,7 +194,7 @@ jobs:
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
       - name: Run shellcheck
         run: |
-          apt-get -qq update && apt-get -qq -y install shellcheck
+          which shellcheck || (apt -q update && apt -yq install shellcheck)
           git ls-files -z '*.sh' | xargs -0 --no-run-if-empty shellcheck
 
   yaml-lint-check:
@@ -210,7 +210,7 @@ jobs:
           submodules: true
       - name: Run yamllint
         run: |
-          which yamllint >/dev/null || ( apt-get update && apt-get install -y yamllint )
+          which yamllint || (apt -q update && apt install -yq yamllint)
           cd ${GITHUB_WORKSPACE}
           if [ ! -f ".yamllint.yml" ]; then
             echo "Downloading default yamllint config file"

--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ exclude_swift_versions: "[{\"swift_version\": \"5.8\"}]"
 ```
 
 Additionally, if your package requires additional installed packages, you can
-use the `pre_build_command`:
+use the `pre_build_command`. For example, to install a package called
+`example`:
 
 ```yaml
-pre_build_command: "apt-get update -y -q && apt-get install -y -q example"
+pre_build_command: "which example || (apt update -q && apt install -yq example"
 ```
 
 macOS and Windows platform support will be available soon.


### PR DESCRIPTION
## Motivation

Some of the soundness checks rely on other tools, e.g. `curl`, `yq`, `yamllint`. These are installed as part of the command in the workflow. Some of them conditionally do this only if the tool wasn't detected as already installed; others check first, using `which`. The latter approach is better because it saves time performing the `apt update` and `apt install` commands if they are not necessary. In CI this is speed up in returning the check status and saves wasted compute. But it also has an important impact locally when running these checks is part of the developer workflow, usually with `act`. 

Concretely, running `soundness-format` (an alias for the expanded `act` command to only run the format check) takes 38s in CI on a recent PR, but only 7s of this is actually running the check. The rest is pulling the Docker base image and doing the installation of `curl`.

## Modifications

This PR updates all the soundness checks to be consistent with what we were already doing for the `yamllint` check: to only install missing tools.

As an aside, the use of `apt` was also inconsistent across the various soundness checks. This PR makes them consistent and:

- Replaces use of `qq` with `q` — the use of `qq` is strongly discouraged in the man page without a no-action specifier.
- Replaces use of `apt-cache` and `apt-get` with just `apt`, which has been supported for a long time.

## Result

Faster CI, faster local workflow.