### PR TITLE
soundness/docs: Add newline before package manifest snippet

### DIFF
--- a/.github/workflows/scripts/check-docs.sh
+++ b/.github/workflows/scripts/check-docs.sh
@@ -24,6 +24,7 @@ fi
 
 log "Editing Package.swift..."
 cat <<EOF >> "Package.swift"
+
 package.dependencies.append(
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", "1.0.0"..<"1.4.0")
 )


### PR DESCRIPTION
## Motivation

The documentation check appends a snippet to the package manifest. When the pacakge manifest doesn't end with a proper newline and happens to end with a comment (as many might with the standard cross-repo comment-fenced package manifest block), it can fail.

Here's an example failed run: https://github.com/swift-server/swift-openapi-async-http-client/actions/runs/12427995650/job/34698796376?pr=44#step:5:219.

## Modifications

Simply insert a newline before the snippet.

## Result

No functional change, but more defensive against some package manifests.