### PR TITLE
License header check ignore symlinks

### DIFF
--- a/.github/workflows/scripts/check-license-header.sh
+++ b/.github/workflows/scripts/check-license-header.sh
@@ -53,6 +53,9 @@ file_paths=$(echo "$exclude_list" | xargs git ls-files)
 while IFS= read -r file_path; do
   file_basename=$(basename -- "${file_path}")
   file_extension="${file_basename##*.}"
+  if [[ -L "${file_path}" ]]; then
+    continue  # Ignore symbolic links
+  fi
 
   # shellcheck disable=SC2001 # We prefer to use sed here instead of bash search/replace
   case "${file_extension}" in


### PR DESCRIPTION
The license header checks are failing when attempting to check symlinks to directories. This removes checks on symlinks altogether. This should be fine even for links to files since even if the symlink is to a file then presumably the linked file will be checked separately.