### PR TITLE
Update the nightly build version to Swift 6.1

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift_version: ['5.8', '5.9', '5.10', '6.0', 'nightly-main', 'nightly-6.0']
+        swift_version: ['5.8', '5.9', '5.10', '6.0', 'nightly-main', 'nightly-6.1']
         os_version: ${{ fromJson(inputs.linux_os_versions) }}
         exclude:
           - ${{ fromJson(inputs.linux_exclude_swift_versions) }}


### PR DESCRIPTION
I noticed when moving over from `apple/swift-nio/.github/workflows/unit_tests.yml@main` that this version didn't seem to move over to the 6.1 nightlies yet. I hope this is the right way about this, but I must admit this is otherwise untested.