### PR TITLE
Update README to reference the correct options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ jobs:
 ### Testing
 
 To enable pull request testing for all supported Swift versions (5.8, 5.9, 5.10,
-6.0, and nightly) on Linux, add the following code example in
+6.0, and nightly) on Linux and Windows, add the following code example in
 `.github/workflows/pull_request.yml`:
 
 ```yaml
@@ -58,10 +58,11 @@ jobs:
 ```
 
 If your package only supports newer compiler versions, you can exclude older
-versions by using the `exclude_swift_versions` workflow input:
+versions by using the `*_exclude_swift_versions` workflow input:
 
 ```yaml
-exclude_swift_versions: "[{\"swift_version\": \"5.8\"}]"
+linux_exclude_swift_versions: "[{\"swift_version\": \"5.8\"}, {\"swift_version\": \"5.9\"}]"
+windows_exclude_swift_versions: "[{\"swift_version\": \"5.9\"}]"
 ```
 
 Additionally, if your package requires additional installed packages, you can
@@ -72,7 +73,7 @@ use the `pre_build_command`. For example, to install a package called
 pre_build_command: "which example || (apt update -q && apt install -yq example"
 ```
 
-macOS and Windows platform support will be available soon.
+macOS platform support will be available soon.
 
 ## Running workflows locally
 


### PR DESCRIPTION
I noticed that the option I copied from the README was no longer functional, so updating the readme accordingly. I also added references to Windows since it seems to be supported now.