### PR TITLE
Update `license_header_check_project_name` to no longer be required

### DIFF
--- a/.github/workflows/scripts/check-license-header.sh
+++ b/.github/workflows/scripts/check-license-header.sh
@@ -17,12 +17,11 @@ log() { printf -- "** %s\n" "$*" >&2; }
 error() { printf -- "** ERROR: %s\n" "$*" >&2; }
 fatal() { error "$@"; exit 1; }
 
-test -n "${PROJECT_NAME:-}" || fatal "PROJECT_NAME unset"
-
 if [ -f .license_header_template ]; then
   # allow projects to override the license header template
   expected_file_header_template=$(cat .license_header_template)
 else
+  test -n "${PROJECT_NAME:-}" || fatal "PROJECT_NAME unset"
   expected_file_header_template="@@===----------------------------------------------------------------------===@@
 @@
 @@ This source file is part of the ${PROJECT_NAME} open source project

--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -37,8 +37,8 @@ on:
         default: true
       license_header_check_project_name:
         type: string
-        description: "Name of the project called out in the license header."
-        required: true
+        description: "Name of the project called out in the license header. Required unless `license_header_check_enabled` is false or a `.license_header_template` file is present."
+        default: ""
       broken_symlink_check_enabled:
         type: boolean
         description: "Boolean to enable the broken symlink check job. Defaults to true."


### PR DESCRIPTION
Updated `license_header_check_project_name` to no longer be required when:
- `license_header_check_enabled` is set to false, or
- a `.license_header_template` file is specified.