### PR TITLE
Allow using GITHUB_TOKEN downstream

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -60,6 +60,10 @@ on:
         type: boolean
         description: "Boolean to enable running build in windows docker container. Defaults to true"
         default: true
+      needs_token:
+        type: boolean
+        description: "Boolean to enable providing the GITHUB_TOKEN to downstream job."
+        default: false
 
 jobs:
   linux-build:
@@ -80,6 +84,10 @@ jobs:
         run: swift --version
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Provide token
+        if: ${{ inputs.needs_token }}
+        run: |
+            echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
       - name: Set environment variables
         if: ${{ inputs.linux_env_vars }}
         run: |
@@ -105,6 +113,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Provide token
+        if: ${{ inputs.needs_token }}
+        run: |
+          echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
       - name: Set environment variables
         if: ${{ inputs.windows_env_vars }}
         run: |


### PR DESCRIPTION
Looking at https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context the `github.token` is only available withins the `steps`. Of the common workflow, but the jobs extending it do not have access. The vscode-swift extension publishes a build of the extension in a separate job, and we want to be able to download it within the common workflow so we can test what is actually might be released.