### PR TITLE
Move from nightly-6.0 to nightly-6.1 on Windows

### DIFF
--- a/.github/workflows/scripts/windows/swift/install-swift-nightly-6.1.ps1
+++ b/.github/workflows/scripts/windows/swift/install-swift-nightly-6.1.ps1
@@ -11,8 +11,8 @@
 ##===----------------------------------------------------------------------===##
 . $PSScriptRoot\install-swift.ps1
 
-$SWIFT_RELEASE_METADATA='http://download.swift.org/swift-6.0-branch/windows10/latest-build.json'
+$SWIFT_RELEASE_METADATA='http://download.swift.org/swift-6.1-branch/windows10/latest-build.json'
 $Release = curl.exe -sL ${SWIFT_RELEASE_METADATA}
-$SWIFT_URL = "https://download.swift.org/swift-6.0-branch/windows10/$($($Release | ConvertFrom-JSON).dir)/$($($Release | ConvertFrom-JSON).download)"
+$SWIFT_URL = "https://download.swift.org/swift-6.1-branch/windows10/$($($Release | ConvertFrom-JSON).dir)/$($($Release | ConvertFrom-JSON).download)"
 
 Install-Swift -Url $SWIFT_URL -Sha256 ""

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -133,7 +133,7 @@ jobs:
         if: ${{ !inputs.enable_windows_docker }}
         run: |
           Invoke-WebRequest -Uri https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/windows/swift/install-swift.ps1 -OutFile $env:TEMP\install-swift.ps1
-          Invoke-WebRequest -Uri https://raw.githubusercontent.com/award999/github-workflows/refs/heads/win-nightly-6.1/.github/workflows/scripts/windows/swift/install-swift-${{ matrix.swift_version }}.ps1 -OutFile $env:TEMP\install-swift-${{ matrix.swift_version }}.ps1
+          Invoke-WebRequest -Uri https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/windows/swift/install-swift-${{ matrix.swift_version }}.ps1 -OutFile $env:TEMP\install-swift-${{ matrix.swift_version }}.ps1
           . $env:TEMP\install-swift-${{ matrix.swift_version }}.ps1
           del $env:TEMP\install-swift*.ps1
       - name: Create test script

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift_version: ['5.9', '6.0', 'nightly', 'nightly-6.0']
+        swift_version: ['5.9', '6.0', 'nightly', 'nightly-6.1']
         exclude:
           - ${{ fromJson(inputs.windows_exclude_swift_versions) }}
     steps:

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -133,7 +133,7 @@ jobs:
         if: ${{ !inputs.enable_windows_docker }}
         run: |
           Invoke-WebRequest -Uri https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/windows/swift/install-swift.ps1 -OutFile $env:TEMP\install-swift.ps1
-          Invoke-WebRequest -Uri https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/windows/swift/install-swift-${{ matrix.swift_version }}.ps1 -OutFile $env:TEMP\install-swift-${{ matrix.swift_version }}.ps1
+          Invoke-WebRequest -Uri https://raw.githubusercontent.com/award999/github-workflows/refs/heads/win-nightly-6.1/.github/workflows/scripts/windows/swift/install-swift-${{ matrix.swift_version }}.ps1 -OutFile $env:TEMP\install-swift-${{ matrix.swift_version }}.ps1
           . $env:TEMP\install-swift-${{ matrix.swift_version }}.ps1
           del $env:TEMP\install-swift*.ps1
       - name: Create test script


### PR DESCRIPTION
Linux migrated so migrating Windows too. Updated script for docker-less flow and docker images do exist for nightly-6.1