### PR TITLE
Update check-docs add plugin to all Package files

### DIFF
--- a/.github/workflows/scripts/check-docs.sh
+++ b/.github/workflows/scripts/check-docs.sh
@@ -26,17 +26,20 @@ if ! command -v yq &> /dev/null; then
   fatal "yq could not be found. Please install yq to proceed."
 fi
 
-if [ ! -f Package.swift ]; then
+package_files=$(find . -maxdepth 1 -name 'Package*.swift')
+if [ -z "$package_files" ]; then
   fatal "Package.swift not found. Please ensure you are running this script from the root of a Swift package."
 fi
 
-log "Editing Package.swift..."
-cat <<EOF >> "Package.swift"
+for package_file in $package_files; do
+  log "Editing $package_file..."
+  cat <<EOF >> "$package_file"
 
 package.dependencies.append(
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", "1.0.0"..<"1.4.0")
 )
 EOF
+done
 
 log "Checking documentation targets..."
 for target in $(yq -r '.builder.configs[].documentation_targets[]' .spi.yml); do


### PR DESCRIPTION
Some Swift packages like swift-argument-parser have multiple package.swift files to handle different tools versions. This change updates check-docs to insert the swift-docc-plugin dependency to all package.swift files so regardless of which one is chosen, the dependency is available.

Fixes: #93