### PR TITLE
Allow specifying additional arguments to pass to the docc check

### DIFF
--- a/.github/workflows/scripts/check-docs.sh
+++ b/.github/workflows/scripts/check-docs.sh
@@ -44,7 +44,8 @@ done
 log "Checking documentation targets..."
 for target in $(yq -r '.builder.configs[].documentation_targets[]' .spi.yml); do
   log "Checking target $target..."
-  swift package plugin generate-documentation --target "$target" --warnings-as-errors --analyze --level detailed
+  # shellcheck disable=SC2086 # We explicitly want to explode "$ADDITIONAL_DOCC_ARGUMENTS" into multiple arguments.
+  swift package plugin generate-documentation --target "$target" --warnings-as-errors --analyze --level detailed $ADDITIONAL_DOCC_ARGUMENTS
 done
 
 log "✅ Found no documentation issues."

--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -23,6 +23,10 @@ on:
         type: string
         description: "Container image for the docs check job. Defaults to latest Swift Ubuntu image."
         default: "swift:6.0-noble"
+      docs_check_additional_arguments:
+        type: string
+        description: "Additional arguments that should be passed to docc"
+        default: ""
       unacceptable_language_check_enabled:
         type: boolean
         description: "Boolean to enable the acceptable language check job. Defaults to true."
@@ -123,6 +127,8 @@ jobs:
         if: ${{ inputs.linux_pre_build_command }}
         run: ${{ inputs.linux_pre_build_command }}
       - name: Run documentation check
+        env:
+          ADDITIONAL_DOCC_ARGUMENTS: ${{ inputs.docs_check_additional_arguments }}
         run: |
           which curl yq || (apt -q update && apt -yq install curl yq)
           curl -s https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/check-docs.sh | bash


### PR DESCRIPTION
We need to pass `--disable-parameters-and-returns-validation` to docc validation for swift-syntax because we don’t want to add documentation for all parameters either (see https://github.com/swiftlang/swift-syntax/pull/2963).