### PR TITLE
Allow specifying a tag that should be used as a baseline for API breakage checks

### DIFF
--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -11,6 +11,10 @@ on:
         type: string
         description: "Path to a file that will be passed as --breakage-allowlist-path to swift package diagnose-api-breaking-changes"
         default: ""
+      api_breakage_check_baseline:
+        type: string
+        description: "The tag against which API breakages that should be used as the baseline for the API breakage check. By default the PR base is used."
+        default: ""
       api_breakage_check_container_image:
         type: string
         description: "Container image for the API breakage check job. Defaults to latest Swift Ubuntu image."
@@ -95,6 +99,8 @@ jobs:
         with:
           persist-credentials: false
           submodules: true
+          fetch-tags: true
+          fetch-depth: 0  # Fetching tags requires fetch-depth: 0 (https://github.com/actions/checkout/issues/1471)
       - name: Mark the workspace as safe
         # https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -102,12 +108,19 @@ jobs:
         if: ${{ inputs.linux_pre_build_command }}
         run: ${{ inputs.linux_pre_build_command }}
       - name: Run API breakage check
+        shell: bash
         run: |
-          git fetch ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} ${GITHUB_BASE_REF}:pull-base-ref
-          if [[ -z '${{ inputs.api_breakage_check_allowlist_path }}' ]]; then
-            swift package diagnose-api-breaking-changes pull-base-ref
+          if [[ -z '${{ inputs.api_breakage_check_baseline }}' ]]; then
+            git fetch ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} ${GITHUB_BASE_REF}:pull-base-ref
+            BASELINE_REF='pull-base-ref'
           else
-            swift package diagnose-api-breaking-changes pull-base-ref --breakage-allowlist-path '${{ inputs.api_breakage_check_allowlist_path }}'
+            BASELINE_REF='${{ inputs.api_breakage_check_baseline }}'
+          fi
+          echo "Using baseline: $BASELINE_REF"
+          if [[ -z '${{ inputs.api_breakage_check_allowlist_path }}' ]]; then
+            swift package diagnose-api-breaking-changes "$BASELINE_REF"
+          else
+            swift package diagnose-api-breaking-changes "$BASELINE_REF" --breakage-allowlist-path '${{ inputs.api_breakage_check_allowlist_path }}'
           fi
 
   docs-check:


### PR DESCRIPTION
Test run: https://github.com/swiftlang/swift-syntax/actions/runs/13777463655/job/38529461132?pr=3009