### PR TITLE
Android support

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -64,6 +64,34 @@ on:
         type: boolean
         description: "Boolean to enable android testing. Defaults to false"
         default: false
+      android_copy_files:
+        type: string
+        description: "Additional files to copy to the Android emulator for testing"
+        default: ""
+      android_cores:
+        type: number
+        description: "Number of cores to use for the Android emulator"
+        default: 2
+      android_api_level:
+        type: number
+        description: "The API level of the Android emulator"
+        default: 30
+      android_channel:
+        type: string
+        description: "Android channel to download the SDK components from - stable, beta, dev, canary"
+        default: "channel"
+      android_profile:
+        type: string
+        description: "Android emulator hardware profile used for creating the AVD"
+        default: "pixel"
+      android_target:
+        type: string
+        description: "Target of the Android system image"
+        default: "aosp_atd"
+      android_test_env:
+        type: string
+        description: "Android emulator test environment variables key=value"
+        default: ""
       android_exclude_swift_versions:
         type: string
         description: "Exclude Android Swift version list (JSON)"
@@ -197,7 +225,7 @@ jobs:
           powershell.exe -NoLogo -File $env:TEMP\test-script\run.ps1; exit $LastExitCode
 
   android-build:
-    name: Android (${{ matrix.swift_version }}
+    name: Android (${{ matrix.swift_version }})
     if: ${{ inputs.enable_android_checks }}
     runs-on: 'ubuntu-24.04'
     strategy:
@@ -217,4 +245,12 @@ jobs:
         uses: skiptools/swift-android-action@v2
         with:
           swift-version: ${{ matrix.swift_version }}
+          swift-build-flags: ${{ (contains(matrix.swift_version, 'nightly') && inputs.swift_nightly_flags) || inputs.swift_flags }}
+          copy-files: ${{ inputs.android_copy_files }}
+          android-cores: ${{ inputs.android_cores }}
+          android-api-level: ${{ inputs.android_api_level }}
+          android-channel: ${{ inputs.android_channel }}
+          android-profile: ${{ inputs.android_profile }}
+          android-target: ${{ inputs.android_target }}
+          android-test-env: ${{ inputs.android_test_env }}
 

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -79,7 +79,7 @@ on:
       android_channel:
         type: string
         description: "Android channel to download the SDK components from - stable, beta, dev, canary"
-        default: "channel"
+        default: "canary"
       android_profile:
         type: string
         description: "Android emulator hardware profile used for creating the AVD"
@@ -247,10 +247,10 @@ jobs:
           swift-version: ${{ matrix.swift_version }}
           swift-build-flags: ${{ (contains(matrix.swift_version, 'nightly') && inputs.swift_nightly_flags) || inputs.swift_flags }}
           copy-files: ${{ inputs.android_copy_files }}
+          test-env: ${{ inputs.android_test_env }}
           android-cores: ${{ inputs.android_cores }}
           android-api-level: ${{ inputs.android_api_level }}
           android-channel: ${{ inputs.android_channel }}
           android-profile: ${{ inputs.android_profile }}
           android-target: ${{ inputs.android_target }}
-          android-test-env: ${{ inputs.android_test_env }}
 

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -60,6 +60,14 @@ on:
         type: boolean
         description: "Boolean to enable running build in windows docker container. Defaults to true"
         default: true
+      enable_android_checks:
+        type: boolean
+        description: "Boolean to enable android testing. Defaults to false"
+        default: false
+      android_exclude_swift_versions:
+        type: string
+        description: "Exclude Android Swift version list (JSON)"
+        default: "[{\"swift_version\": \"\"}]"
       needs_token:
         type: boolean
         description: "Boolean to enable providing the GITHUB_TOKEN to downstream job."
@@ -187,3 +195,26 @@ jobs:
           Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
           RefreshEnv
           powershell.exe -NoLogo -File $env:TEMP\test-script\run.ps1; exit $LastExitCode
+
+  android-build:
+    name: Android (${{ matrix.swift_version }}
+    if: ${{ inputs.enable_android_checks }}
+    runs-on: 'ubuntu-24.04'
+    strategy:
+      fail-fast: false
+      matrix:
+        swift_version: ['nightly-6.1']
+        exclude:
+          - ${{ fromJson(inputs.android_exclude_swift_versions) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Provide token
+        if: ${{ inputs.needs_token }}
+        run: |
+            echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+      - name: Build / Test
+        uses: skiptools/swift-android-action@v2
+        with:
+          swift-version: ${{ matrix.swift_version }}
+


### PR DESCRIPTION
As discussed in https://github.com/swiftlang/github-workflows/issues/83, and now that the Android SDK nightly-6.1 supports Swift Testing (https://github.com/swiftlang/swift-package-manager/issues/8362), this PR adds experimental support for cross-compiling Swift packages for Android and running their tests on an Android emulator. It is only run when the `enable_android_checks` input is set to `true`, making it opt-in for now.

It uses [swift-android-action](https://github.com/marketplace/actions/swift-android-action) to set up the environment and run the tests, which is the same workflow that powers https://swift-everywhere.org and various other Swift CI workflows. This action, in turn, delegates to the [reactivecircus/android-emulator-runner](https://github.com/reactivecircus/android-emulator-runner) workflow to set up and run the emulator based in the inputs passed to the workflow (`android_api_level`, `android_channel`, `android_profile`, and `android_target`). Support for transferring specific files to the Android emulator (with `android_copy_files`) and setting custom test environment variables (with `android_test_env`) enable customization of the test environment (for example, see https://github.com/jpsim/Yams/blob/main/.github/workflows/swiftpm.yml#L146).

This works towards the one of the goals of the [Android Workgroup](https://github.com/swiftlang/swift-org-website/pull/925) to provide continuous integration support for Android. A successful run of this workflow can be seen at https://github.com/marcprux/swift-algorithms/actions/runs/13838259992

Closes https://github.com/swiftlang/github-workflows/issues/83.