### PR TITLE
Append swift-docc-plugin only when needed

### DIFF
--- a/.github/workflows/scripts/check-docs.sh
+++ b/.github/workflows/scripts/check-docs.sh
@@ -31,15 +31,23 @@ if [ -z "$package_files" ]; then
   fatal "Package.swift not found. Please ensure you are running this script from the root of a Swift package."
 fi
 
-for package_file in $package_files; do
-  log "Editing $package_file..."
-  cat <<EOF >> "$package_file"
+# yq 3.1.0-3 doesn't have filter, otherwise we could replace the grep call with "filter(.identity == "swift-docc-plugin") | keys | .[]"
+hasDoccPlugin=$(swift package dump-package | yq -r '.dependencies[].sourceControl' | grep -e "\"identity\": \"swift-docc-plugin\"" || true)
+if [[ -n $hasDoccPlugin ]]
+then
+    log "swift-docc-plugin already exists"
+else
+    log "Appending swift-docc-plugin"
+    for package_file in $package_files; do
+      log "Editing $package_file..."
+      cat <<EOF >> "$package_file"
 
 package.dependencies.append(
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", "1.0.0"..<"1.4.0")
 )
 EOF
-done
+    done
+fi
 
 log "Checking documentation targets..."
 for target in $(yq -r '.builder.configs[].documentation_targets[]' .spi.yml); do


### PR DESCRIPTION
Currently, the `docs-check:` workflow always adds the `swift-docc-plugin` dependency, forcing adopters to remove the dependency  from their package. This PR edits the docs check to skip adding the dependency when already present.

* A package with swift-docc-plugin: https://github.com/fboemer/swift-homomorphic-encryption/actions/runs/13997582365/job/39196407070?pr=3#step:5:222

* A package without swift-docc-plugin: https://github.com/fboemer/swift-homomorphic-encryption/actions/runs/13997685223/job/39196742443#step:5:222
