### PR TITLE
Apply concurrency control to swift-package-test, cancelling previously running workflows of the same kind

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -65,6 +65,11 @@ on:
         description: "Boolean to enable providing the GITHUB_TOKEN to downstream job."
         default: false
 
+## We are cancelling previously triggered workflow runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}-package-test
+  cancel-in-progress: true
+
 jobs:
   linux-build:
     name: Linux (${{ matrix.swift_version }} - ${{ matrix.os_version }})


### PR DESCRIPTION
Hello! 👋
This change is derived from https://github.com/swiftlang/swift-format/pull/976.
It adds concurrency control to ensure that only one active workflow is running per pull request, preventing duplicate workflow executions for open PRs.