### PR TITLE
removes deprecated option in docc soundness check script

### DIFF
--- a/.github/workflows/scripts/check-docs.sh
+++ b/.github/workflows/scripts/check-docs.sh
@@ -53,7 +53,7 @@ log "Checking documentation targets..."
 for target in $(yq -r '.builder.configs[].documentation_targets[]' .spi.yml); do
   log "Checking target $target..."
   # shellcheck disable=SC2086 # We explicitly want to explode "$ADDITIONAL_DOCC_ARGUMENTS" into multiple arguments.
-  swift package plugin generate-documentation --target "$target" --warnings-as-errors --analyze --level detailed $ADDITIONAL_DOCC_ARGUMENTS
+  swift package plugin generate-documentation --target "$target" --warnings-as-errors --analyze $ADDITIONAL_DOCC_ARGUMENTS
 done
 
 log "✅ Found no documentation issues."


### PR DESCRIPTION
- verified with Swift 5.10, 6, and 6.1. Prior to swift 6, level was related to providing analysis coverage, but that doesn't appear to be the intent with this check.
- with Swift 5.10, the --level option was ignored - no warning was generated
- post Swift 6, that option was renamed --coverage-summary-level, but still is a no-op without also including
the option --experimental-documentation-coverage

resolves #116 