### PR TITLE
Update automerger template and documentation

### DIFF
--- a/.github/workflows/create_automerge_pr.yml
+++ b/.github/workflows/create_automerge_pr.yml
@@ -33,12 +33,13 @@ name: Create automerge PR
 # ```
 #
 # PRs created by GitHub Actions don't kick off further actions (https://github.com/peter-evans/create-pull-request/blob/d57e551ebc1a16dee0b8c9ea6d24dba7627a6e35/docs/concepts-guidelines.md#triggering-further-workflow-runs).
-# As a workaround, we mark automerge PRs that are created by GitHub actions as draft and trigger the GitHub actions by marking the PR as ready for review. But we don't want to re-trigger testing this when a normal user's PR is marked as ready for review.
-# For this the pull request workflow in the repository needs to add the `ready_for_review` type to its `pull_request` trigger and add the following condition as an `if` condition to all jobs:
-#
+# As a workaround, we mark automerge PRs that are created by GitHub actions as draft and trigger the GitHub actions by marking the PR as ready for review. `ready_for_review` must be added to the PR types for this purpose, eg.
 # ```
-# if: (github.event.action != 'ready_for_review') || (github.event.action == 'ready_for_review' && github.event.pull_request.user.login == 'github-actions[bot]')
+# on:
+#  pull_request:
+#    types: [..., ready_for_review]
 # ```
+# Unfortunately this will also re-trigger testing evenon a normal user's PR (which may have already been tested), but skipping them causes the checks to reset so this is the best we can do for now.
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
We cannot skip running actions for regular users here, it results in the checks all being reset without any way to then make them run.