### PR TITLE
Add 60 minute timeout to build step of macos-build matrix job

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -139,6 +139,7 @@ jobs:
         run: ${{ inputs.macos_pre_build_command }}
       - name: Build / Test
         run: ${{ inputs.macos_build_command }}
+        timeout-minutes: 60
 
   linux-build:
     name: Linux (${{ matrix.swift_version }} - ${{ matrix.os_version }})


### PR DESCRIPTION
### Motivation

When macOS jobs hang, they have a knock-on effect on other projects because they run on a dedicated pool. There is currently no timeout set on the job or steps in this matrix, so it defaults to 6 hours. This is unlike the Windows equivalent, which has a timeout of 60 minutes. 

### Modifications

Add 60 minute timeout to build step of macos-build matrix job.

### Result

macOS jobs that are taking longer than 60 minutes will timeout, which will reduce the impact of hanging jobs on other projects.
