### PR TITLE
Add swift version files as exclusions to the license header checks

### DIFF
--- a/.github/workflows/scripts/check-license-header.sh
+++ b/.github/workflows/scripts/check-license-header.sh
@@ -46,7 +46,7 @@ dynamic_exclude_list=( )
 
 if [[ -f .licenseignore ]]; then
   static_exclude_list+=( '":(exclude).licenseignore"' )
-  IFS=$'\n' read -d '' -r -a dynamic_exclude_list <<< $(sed -E 's/^(.*)$/":(exclude)\1"/' <.licenseignore)
+  IFS=$'\n' read -d '' -r -a dynamic_exclude_list <<< "$(sed -E 's/^(.*)$/":(exclude)\1"/' <.licenseignore)"
 fi
 
 exclude_list=( "${static_exclude_list[@]}" "${dynamic_exclude_list[@]}" )

--- a/.github/workflows/scripts/check-license-header.sh
+++ b/.github/workflows/scripts/check-license-header.sh
@@ -47,6 +47,8 @@ else
   exclude_list=":(exclude).license_header_template"
 fi
 
+exclude_list="${exclude_list}:(exclude).swift-version" # Swift version files will never have license headers in them
+
 file_paths=$(echo "$exclude_list" | xargs git ls-files)
 
 while IFS= read -r file_path; do

--- a/.github/workflows/scripts/check-license-header.sh
+++ b/.github/workflows/scripts/check-license-header.sh
@@ -39,17 +39,20 @@ fi
 
 paths_with_missing_license=( )
 
+static_exclude_list=( )
+static_exclude_list+=( '":(exclude).license_header_template"' )
+static_exclude_list+=( '":(exclude).swift-version"' ) # Swift version files do not have comments nor licenses in them
+dynamic_exclude_list=( )
+
 if [[ -f .licenseignore ]]; then
-  static_exclude_list='":(exclude).licenseignore" ":(exclude).license_header_template" '
-  dynamic_exclude_list=$(tr '\n' '\0' < .licenseignore | xargs -0 -I% printf '":(exclude)%" ')
-  exclude_list=$static_exclude_list$dynamic_exclude_list
-else
-  exclude_list=":(exclude).license_header_template"
+  static_exclude_list+=( '":(exclude).licenseignore"' )
+  IFS=$'\n' read -d '' -r -a dynamic_exclude_list <<< $(sed -E 's/^(.*)$/":(exclude)\1"/' <.licenseignore)
 fi
 
-exclude_list="${exclude_list}:(exclude).swift-version" # Swift version files will never have license headers in them
+exclude_list=( "${static_exclude_list[@]}" "${dynamic_exclude_list[@]}" )
+excludes=$(IFS=" " ; echo "${exclude_list[*]}")
 
-file_paths=$(echo "$exclude_list" | xargs git ls-files)
+file_paths=$(echo "$excludes" | xargs git ls-files)
 
 while IFS= read -r file_path; do
   file_basename=$(basename -- "${file_path}")


### PR DESCRIPTION
Swift version files are designed to be very simple one-line files with the
intended version of swift to be used for a repo or directory. This helps to
support ad-hoc scripting use-cases where the file can be read as a script
variable without any extra parsing so that the correct toolchain can be
used based on directory name, etc. These files won't have license headers
in them so there's no need for the license check to check for that.

Add `.swift-version` to the exclusion list automatically so that repos
don't need to add them manually to the `.licenseignore` file on their own.