### PR TITLE
Fix addition of swift version file as automatic exclusion to the license check

### DIFF
--- a/.github/workflows/scripts/check-license-header.sh
+++ b/.github/workflows/scripts/check-license-header.sh
@@ -46,7 +46,7 @@ dynamic_exclude_list=( )
 
 if [[ -f .licenseignore ]]; then
   static_exclude_list+=( '":(exclude).licenseignore"' )
-  IFS=$'\n' read -d '' -r -a dynamic_exclude_list <<< "$(sed -E 's/^(.*)$/":(exclude)\1"/' <.licenseignore)"
+  IFS=$'\n' read -r -a dynamic_exclude_list <<< "$(sed -E 's/^(.*)$/":(exclude)\1"/' <.licenseignore)"
 fi
 
 exclude_list=( "${static_exclude_list[@]}" "${dynamic_exclude_list[@]}" )


### PR DESCRIPTION
The delimiter argument to the read command with an empty delimiter is causing silent errors.