### PR TITLE
Retry curl operations in CI scripts

### DIFF
--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -144,7 +144,7 @@ jobs:
           ADDITIONAL_DOCC_ARGUMENTS: ${{ inputs.docs_check_additional_arguments }}
         run: |
           which curl yq || (apt -q update && apt -yq install curl yq)
-          curl -s https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/check-docs.sh | bash
+          curl -s --retry 3 https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/check-docs.sh | bash
 
   unacceptable-language-check:
     name: Unacceptable language check
@@ -160,7 +160,7 @@ jobs:
       - name: Run unacceptable language check
         env:
           UNACCEPTABLE_WORD_LIST: ${{ inputs.unacceptable_language_check_word_list}}
-        run: curl -s https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/check-unacceptable-language.sh | bash
+        run: curl -s --retry 3 https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/check-unacceptable-language.sh | bash
 
   license-header-check:
     name: License headers check
@@ -176,7 +176,7 @@ jobs:
       - name: Run license header check
         env:
           PROJECT_NAME: ${{ inputs.license_header_check_project_name }}
-        run: curl -s https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/check-license-header.sh | bash
+        run: curl -s --retry 3 https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/check-license-header.sh | bash
 
   broken-symlink-check:
     name: Broken symlinks check
@@ -190,7 +190,7 @@ jobs:
           persist-credentials: false
           submodules: true
       - name: Run broken symlinks check
-        run: curl -s https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/check-broken-symlinks.sh | bash
+        run: curl -s --retry 3 https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/check-broken-symlinks.sh | bash
 
   format-check:
     name: Format check
@@ -211,7 +211,7 @@ jobs:
       - name: Run format check
         run: |
           which curl || (apt -q update && apt -yq install curl)
-          curl -s https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/check-swift-format.sh | bash
+          curl -s --retry 3 https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/check-swift-format.sh | bash
 
   shell-check:
     name: Shell check
@@ -251,7 +251,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}
           if [ ! -f ".yamllint.yml" ]; then
             echo "Downloading default yamllint config file"
-            curl -s https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/configs/yamllint.yml > .yamllint.yml
+            curl -s --retry 3 https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/configs/yamllint.yml > .yamllint.yml
           fi
           yamllint --strict --config-file .yamllint.yml .
 
@@ -272,6 +272,6 @@ jobs:
           cd ${GITHUB_WORKSPACE}
           if [ ! -f ".flake8" ]; then
             echo "Downloading default flake8 config file"
-            curl -s https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/configs/.flake8 > .flake8
+            curl -s --retry 3 https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/configs/.flake8 > .flake8
           fi
           flake8


### PR DESCRIPTION
Some 429: Too many requests responses have been seen when attempting to curl remote CI scripts.

This change adds `--retry 3` which means that curl will retry 3 times on transient error codes, first for 1 second and then doubled each retry.

from `man curl`
```
       --retry <num>
              If a transient error is returned when curl tries to perform a transfer, it
              retries this number of times before giving up. Setting the number to 0
              makes curl do no retries (which is the default). Transient error means
              either: a timeout, an FTP 4xx response code or an HTTP 408, 429, 500, 502,
              503 or 504 response code.

              When curl is about to retry a transfer, it first waits one second and then
              for all forthcoming retries it doubles the waiting time until it reaches 10
              minutes which then remains delay between the rest of the retries. By using
              --retry-delay you disable this exponential backoff algorithm. See also
              --retry-max-time to limit the total time allowed for retries.

              curl complies with the Retry-After: response header if one was present to
              know when to issue the next retry (added in 7.66.0).

              If --retry is provided several times, the last set value is used.
```