### PR TITLE
Add missing flags for macOS builds

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Pre-build
         run: ${{ inputs.macos_pre_build_command }}
       - name: Build / Test
-        run: ${{ inputs.macos_build_command }}
+        run: ${{ inputs.macos_build_command }} ${{ (contains(matrix.swift_version, 'nightly') && inputs.swift_nightly_flags) || inputs.swift_flags }}
         timeout-minutes: 60
 
   linux-build:


### PR DESCRIPTION
Fixes a bug where swift_flags would not be used for macOS builds.