### PR TITLE
Remove upper bound limit on docc plugin

### DIFF
--- a/.github/workflows/scripts/check-docs.sh
+++ b/.github/workflows/scripts/check-docs.sh
@@ -43,7 +43,7 @@ else
       cat <<EOF >> "$package_file"
 
 package.dependencies.append(
-    .package(url: "https://github.com/swiftlang/swift-docc-plugin", "1.0.0"..<"1.4.0")
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0")
 )
 EOF
     done


### PR DESCRIPTION
Updates check-docs.sh to use any 1.x.y version of `swift-docc-plugin`. This fixes a bug where docs can't be generated using flags like: `--symbol-graph-minimum-access-level` etc.