### PR TITLE
Remove Xcode 16.0 & 16.1

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -6,7 +6,7 @@ on:
       macos_xcode_versions:
         type: string
         description: "Xcode version list (JSON)"
-        default: "[\"16.0\", \"16.1\", \"16.2\", \"16.3\"]"
+        default: "[\"16.2\", \"16.3\"]"
       macos_exclude_xcode_versions:
         type: string
         description: "Exclude Xcode version list (JSON)"


### PR DESCRIPTION
These images have been removed from the swift ci images and should no longer be tested against.