### PR TITLE
Fix the Swift versions list for Windows

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -34,7 +34,8 @@ on:
       windows_swift_versions:
         type: string
         description: "Include Windows Swift version list (JSON)"
-        default: "[\"5.9\", \"5.10\", \"6.0\", \"6.1\", \"nightly\", \"nightly-6.2\"]"
+        # "5.10" is omitted for Windows because the container image is broken.
+        default: "[\"5.9\", \"6.0\", \"6.1\", \"nightly\", \"nightly-6.2\"]"
       windows_exclude_swift_versions:
         type: string
         description: "Exclude Windows Swift version list (JSON)"

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -34,7 +34,7 @@ on:
       windows_swift_versions:
         type: string
         description: "Include Windows Swift version list (JSON)"
-        default: "[\"5.9\", \"6.0\", \"6.1\", \"nightly\", \"nightly-6.2\"]"
+        default: "[\"5.9\", \"5.10\", \"6.0\", \"6.1\", \"nightly\", \"nightly-6.2\"]"
       windows_exclude_swift_versions:
         type: string
         description: "Exclude Windows Swift version list (JSON)"


### PR DESCRIPTION
5.10 was omitted. This adds a comment explaining the omission.