### PR TITLE
Enable the api breaking check to work for private repos

### DIFF
--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -97,7 +97,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          persist-credentials: false
+          # This is set to true since swift package diagnose-api-breaking-changes is
+          # cloning the repo again and without it being set to true this job won't work for
+          # private repos.
+          persist-credentials: true 
           submodules: true
           fetch-tags: true
           fetch-depth: 0  # Fetching tags requires fetch-depth: 0 (https://github.com/actions/checkout/issues/1471)

--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -100,7 +100,7 @@ jobs:
           # This is set to true since swift package diagnose-api-breaking-changes is
           # cloning the repo again and without it being set to true this job won't work for
           # private repos.
-          persist-credentials: true 
+          persist-credentials: true
           submodules: true
           fetch-tags: true
           fetch-depth: 0  # Fetching tags requires fetch-depth: 0 (https://github.com/actions/checkout/issues/1471)


### PR DESCRIPTION
# Motivation

Currently, the API breaking check is not working for private repos since it requires git credentials to be configured so that it can clone the repo again

# Modifications

This sets the `persist-credentials` to `true` for only the diagnose API breaking checks job since that one has a credible need to re-use the git credentials

# Result

API breaking change checking now works for private repos