### PR TITLE
Support RPM distros when building with Swift static Linux/Wasm SDKs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,6 +10,7 @@ jobs:
     uses: ./.github/workflows/swift_package_test.yml
     with:
       # Linux
+      linux_os_versions: '["jammy", "rhel-ubi9"]'
       linux_build_command: |
         mkdir MyPackage
         cd MyPackage

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -234,7 +234,7 @@ jobs:
         run: |
           ${{ inputs.linux_static_sdk_pre_build_command }}
           which curl || (apt -q update && apt -yq install curl)
-          curl -s --retry 3 https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/install-and-build-with-sdk.sh | \
+          curl -s --retry 3 https://raw.githubusercontent.com/jrflat/github-workflows/refs/heads/support-rpm-distros-sdk-builds/.github/workflows/scripts/install-and-build-with-sdk.sh | \
           bash -s -- --static --flags="$BUILD_FLAGS" ${{ matrix.swift_version }}
 
   wasm-sdk-build:
@@ -272,7 +272,7 @@ jobs:
         run: |
           ${{ inputs.wasm_sdk_pre_build_command }}
           which curl || (apt -q update && apt -yq install curl)
-          curl -s --retry 3 https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/install-and-build-with-sdk.sh | \
+          curl -s --retry 3 https://raw.githubusercontent.com/jrflat/github-workflows/refs/heads/support-rpm-distros-sdk-builds/.github/workflows/scripts/install-and-build-with-sdk.sh | \
           bash -s -- --wasm --flags="$BUILD_FLAGS" ${{ matrix.swift_version }}
 
   windows-build:

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -234,7 +234,7 @@ jobs:
         run: |
           ${{ inputs.linux_static_sdk_pre_build_command }}
           which curl || (apt -q update && apt -yq install curl)
-          curl -s --retry 3 https://raw.githubusercontent.com/jrflat/github-workflows/refs/heads/support-rpm-distros-sdk-builds/.github/workflows/scripts/install-and-build-with-sdk.sh | \
+          curl -s --retry 3 https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/install-and-build-with-sdk.sh | \
           bash -s -- --static --flags="$BUILD_FLAGS" ${{ matrix.swift_version }}
 
   wasm-sdk-build:
@@ -272,7 +272,7 @@ jobs:
         run: |
           ${{ inputs.wasm_sdk_pre_build_command }}
           which curl || (apt -q update && apt -yq install curl)
-          curl -s --retry 3 https://raw.githubusercontent.com/jrflat/github-workflows/refs/heads/support-rpm-distros-sdk-builds/.github/workflows/scripts/install-and-build-with-sdk.sh | \
+          curl -s --retry 3 https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/install-and-build-with-sdk.sh | \
           bash -s -- --wasm --flags="$BUILD_FLAGS" ${{ matrix.swift_version }}
 
   windows-build:


### PR DESCRIPTION
Detect package manager (`apt`, `dnf`, or `yum`) to use for installing dependencies. Also, update `initialize_os_info()` to use the expected OS name for the download URL (such as `ubi9`), which might not match the `ID` and `VERSION_ID` in `/etc/os-release`.

Verified the script now works on rhel-ubi9, fedora39, amazonlinux2, and debian12 containers. This testing also revealed an issue where the script would continue running and fail if the required toolchain couldn't be found, rather than exiting cleanly as intended. I fixed this so the script exits successfully and doesn't fail the CI job in this case.

Resolves https://github.com/swiftlang/github-workflows/issues/146