### PR TITLE
Add `enable_embedded_wasm_sdk_build` to `swift_package_test.yml`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,10 +9,10 @@ jobs:
     name: Test Embedded Swift SDKs
     uses: ./.github/workflows/swift_package_test.yml
     with:
+      # Wasm
       enable_linux_checks: false
       enable_macos_checks: false
       enable_windows_checks: false
-      # Wasm
       wasm_sdk_pre_build_command: |
         mkdir MyPackage
         cd MyPackage

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,6 +5,17 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
+  tests_with_docker_embedded_swift:
+    name: Test Embedded Swift SDKs
+    uses: ./.github/workflows/swift_package_test.yml
+    with:
+      # Wasm
+      wasm_sdk_pre_build_command: |
+        mkdir MyPackage
+        cd MyPackage
+        swift package init --type executable
+      enable_embedded_wasm_sdk_build: true
+
   tests_with_docker:
     name: Test with Docker
     uses: ./.github/workflows/swift_package_test.yml

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
       wasm_sdk_pre_build_command: |
         mkdir MyPackage
         cd MyPackage
-        swift package init --type executable
+        swift package init --type library
       enable_embedded_wasm_sdk_build: true
 
   tests_with_docker:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,8 +9,9 @@ jobs:
     name: Test Embedded Swift SDKs
     uses: ./.github/workflows/swift_package_test.yml
     with:
-      enable_windows_docker: false
       enable_linux_checks: false
+      enable_macos_checks: false
+      enable_windows_checks: false
       # Wasm
       wasm_sdk_pre_build_command: |
         mkdir MyPackage

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,6 +9,8 @@ jobs:
     name: Test Embedded Swift SDKs
     uses: ./.github/workflows/swift_package_test.yml
     with:
+      enable_windows_docker: false
+      enable_linux_checks: false
       # Wasm
       wasm_sdk_pre_build_command: |
         mkdir MyPackage

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -283,6 +283,7 @@ jobs:
           curl -s --retry 3 https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/install-and-build-with-sdk.sh | \
           bash -s -- --wasm --flags="$BUILD_FLAGS" ${{ matrix.swift_version }}  wasm-sdk-build:
 
+  embedded-wasm-sdk-build:
     name: Embedded Swift SDK for Wasm Build (${{ matrix.swift_version }} - ${{ matrix.os_version }})
     if: ${{ inputs.enable_embedded_wasm_sdk_build }}
     runs-on: ubuntu-latest

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -318,7 +318,7 @@ jobs:
         run: |
           ${{ inputs.wasm_sdk_pre_build_command }}
           which curl || (apt -q update && apt -yq install curl)
-          curl -s --retry 3 https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/install-and-build-with-sdk.sh | \
+          curl -s --retry 3 https://raw.githubusercontent.com/MaxDesiatov/github-workflows/refs/heads/patch-1/.github/workflows/scripts/install-and-build-with-sdk.sh | \
           bash -s -- --embedded-wasm --flags="$BUILD_FLAGS" ${{ matrix.swift_version }}
 
   windows-build:

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -65,7 +65,7 @@ on:
         default: ""
       linux_static_sdk_pre_build_command:
         type: string
-        description: "Linux command to execute before building the Swift package with the static Linux Swift SDK"
+        description: "Linux command to execute before building the Swift package with the Static Linux Swift SDK"
         default: ""
       wasm_sdk_pre_build_command:
         type: string

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -322,7 +322,7 @@ jobs:
         run: |
           ${{ inputs.wasm_sdk_pre_build_command }}
           which curl || (apt -q update && apt -yq install curl)
-          curl -s --retry 3 https://raw.githubusercontent.com/MaxDesiatov/github-workflows/refs/heads/patch-1/.github/workflows/scripts/install-and-build-with-sdk.sh | \
+          curl -s --retry 3 https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/install-and-build-with-sdk.sh | \
           bash -s -- --embedded-wasm --flags="$BUILD_FLAGS" ${{ matrix.swift_version }}
 
   windows-build:

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -38,7 +38,7 @@ on:
       wasm_sdk_versions:
         type: string
         description: "Wasm Swift SDK version list (JSON)"
-        default: "[\"nightly\", \"nightly-6.2\"]"
+        default: "[\"nightly-main\", \"nightly-6.2\"]"
       windows_swift_versions:
         type: string
         description: "Include Windows Swift version list (JSON)"

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -33,12 +33,12 @@ on:
         default: "[\"jammy\"]"
       linux_static_sdk_versions:
         type: string
-        description: "Linux Swift static SDK version list (JSON)"
+        description: "Static Linux Swift SDK version list (JSON)"
         default: "[\"nightly-6.2\"]"
       wasm_sdk_versions:
         type: string
-        description: "Swift Wasm SDK version list (JSON)"
-        default: "[\"nightly-6.2\"]"
+        description: "Wasm Swift SDK version list (JSON)"
+        default: "[\"nightly\", \"nightly-6.2\"]"
       windows_swift_versions:
         type: string
         description: "Include Windows Swift version list (JSON)"
@@ -61,11 +61,15 @@ on:
         default: ""
       linux_static_sdk_pre_build_command:
         type: string
-        description: "Linux command to execute before building the Swift package with the static SDK"
+        description: "Linux command to execute before building the Swift package with the static Linux Swift SDK"
         default: ""
       wasm_sdk_pre_build_command:
         type: string
-        description: "Linux command to execute before building the Swift package with the Wasm SDK"
+        description: "Linux command to execute before building the Swift package with the Embedded Swift SDK for Wasm"
+        default: ""
+      embedded_wasm_sdk_pre_build_command:
+        type: string
+        description: "Linux command to execute before building the Swift package with the Embedded Swift SDK for Wasm"
         default: ""
       macos_pre_build_command:
         type: string
@@ -105,11 +109,15 @@ on:
         default: true
       enable_linux_static_sdk_build:
         type: boolean
-        description: "Boolean to enable building with the Linux static SDK. Defaults to false"
+        description: "Boolean to enable building with the Static Linux Swift SDK. Defaults to false"
         default: false
       enable_wasm_sdk_build:
         type: boolean
-        description: "Boolean to enable building with the Wasm SDK. Defaults to false"
+        description: "Boolean to enable building with the Swift SDK for Wasm. Defaults to false"
+        default: false
+      enable_embedded_wasm_sdk_build:
+        type: boolean
+        description: "Boolean to enable building with the Embedded Swift SDK for Wasm. Defaults to false"
         default: false
       enable_macos_checks:
         type: boolean
@@ -200,7 +208,7 @@ jobs:
         run: ${{ inputs.linux_build_command }} ${{ (contains(matrix.swift_version, 'nightly') && inputs.swift_nightly_flags) || inputs.swift_flags }}
 
   linux-static-sdk-build:
-    name: Linux Static SDK Build (${{ matrix.swift_version }} - ${{ matrix.os_version }})
+    name: Static Linux Swift SDK Build (${{ matrix.swift_version }} - ${{ matrix.os_version }})
     if: ${{ inputs.enable_linux_static_sdk_build }}
     runs-on: ubuntu-latest
     strategy:
@@ -228,7 +236,7 @@ jobs:
             done
       - name: Pre-build
         run: ${{ inputs.linux_pre_build_command }}
-      - name: Install static SDK and build
+      - name: Install Static Linux Swift SDK and build
         env:
           BUILD_FLAGS: ${{ (contains(matrix.swift_version, 'nightly') && inputs.swift_nightly_flags) || inputs.swift_flags }}
         run: |
@@ -238,7 +246,7 @@ jobs:
           bash -s -- --static --flags="$BUILD_FLAGS" ${{ matrix.swift_version }}
 
   wasm-sdk-build:
-    name: Wasm SDK Build (${{ matrix.swift_version }} - ${{ matrix.os_version }})
+    name: Swift SDK for Wasm Build (${{ matrix.swift_version }} - ${{ matrix.os_version }})
     if: ${{ inputs.enable_wasm_sdk_build }}
     runs-on: ubuntu-latest
     strategy:
@@ -266,14 +274,51 @@ jobs:
             done
       - name: Pre-build
         run: ${{ inputs.linux_pre_build_command }}
-      - name: Install Wasm SDK and build
+      - name: Install Swift SDK for Wasm and build
         env:
           BUILD_FLAGS: ${{ (contains(matrix.swift_version, 'nightly') && inputs.swift_nightly_flags) || inputs.swift_flags }}
         run: |
           ${{ inputs.wasm_sdk_pre_build_command }}
           which curl || (apt -q update && apt -yq install curl)
           curl -s --retry 3 https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/install-and-build-with-sdk.sh | \
-          bash -s -- --wasm --flags="$BUILD_FLAGS" ${{ matrix.swift_version }}
+          bash -s -- --wasm --flags="$BUILD_FLAGS" ${{ matrix.swift_version }}  wasm-sdk-build:
+
+    name: Embedded Swift SDK for Wasm Build (${{ matrix.swift_version }} - ${{ matrix.os_version }})
+    if: ${{ inputs.enable_embedded_wasm_sdk_build }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        swift_version: ${{ fromJson(inputs.wasm_sdk_versions) }}
+        os_version: ${{ fromJson(inputs.linux_os_versions) }}
+    container:
+      image: ${{ (contains(matrix.swift_version, 'nightly') && 'swiftlang/swift') || 'swift' }}:${{ matrix.swift_version }}-${{ matrix.os_version }}
+    steps:
+      - name: Swift version
+        run: swift --version
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Provide token
+        if: ${{ inputs.needs_token }}
+        run: |
+            echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+      - name: Set environment variables
+        if: ${{ inputs.linux_env_vars }}
+        run: |
+            for i in "${{ inputs.linux_env_vars }}"
+            do
+              printf "%s\n" $i >> $GITHUB_ENV
+            done
+      - name: Pre-build
+        run: ${{ inputs.linux_pre_build_command }}
+      - name: Install Swift SDK for Wasm and build
+        env:
+          BUILD_FLAGS: ${{ (contains(matrix.swift_version, 'nightly') && inputs.swift_nightly_flags) || inputs.swift_flags }}
+        run: |
+          ${{ inputs.wasm_sdk_pre_build_command }}
+          which curl || (apt -q update && apt -yq install curl)
+          curl -s --retry 3 https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/install-and-build-with-sdk.sh | \
+          bash -s -- --embedded-wasm --flags="$BUILD_FLAGS" ${{ matrix.swift_version }}
 
   windows-build:
     name: Windows (${{ matrix.swift_version }} - windows-2022)

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -283,7 +283,7 @@ jobs:
           ${{ inputs.wasm_sdk_pre_build_command }}
           which curl || (apt -q update && apt -yq install curl)
           curl -s --retry 3 https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/install-and-build-with-sdk.sh | \
-          bash -s -- --wasm --flags="$BUILD_FLAGS" ${{ matrix.swift_version }}  wasm-sdk-build:
+          bash -s -- --wasm --flags="$BUILD_FLAGS" ${{ matrix.swift_version }}
 
   embedded-wasm-sdk-build:
     name: Embedded Swift SDK for Wasm Build (${{ matrix.swift_version }} - ${{ matrix.os_version }})

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -39,6 +39,10 @@ on:
         type: string
         description: "Wasm Swift SDK version list (JSON)"
         default: "[\"nightly-main\", \"nightly-6.2\"]"
+      wasm_exclude_swift_versions:
+        type: string
+        description: "Exclude Wasm Swift SDK version list (JSON)"
+        default: "[{\"swift_version\": \"\"}]"
       windows_swift_versions:
         type: string
         description: "Include Windows Swift version list (JSON)"
@@ -64,10 +68,6 @@ on:
         description: "Linux command to execute before building the Swift package with the static Linux Swift SDK"
         default: ""
       wasm_sdk_pre_build_command:
-        type: string
-        description: "Linux command to execute before building the Swift package with the Embedded Swift SDK for Wasm"
-        default: ""
-      embedded_wasm_sdk_pre_build_command:
         type: string
         description: "Linux command to execute before building the Swift package with the Embedded Swift SDK for Wasm"
         default: ""
@@ -254,6 +254,8 @@ jobs:
       matrix:
         swift_version: ${{ fromJson(inputs.wasm_sdk_versions) }}
         os_version: ${{ fromJson(inputs.linux_os_versions) }}
+        exclude:
+          - ${{ fromJson(inputs.wasm_exclude_swift_versions) }}
     container:
       image: ${{ (contains(matrix.swift_version, 'nightly') && 'swiftlang/swift') || 'swift' }}:${{ matrix.swift_version }}-${{ matrix.os_version }}
     steps:
@@ -292,6 +294,8 @@ jobs:
       matrix:
         swift_version: ${{ fromJson(inputs.wasm_sdk_versions) }}
         os_version: ${{ fromJson(inputs.linux_os_versions) }}
+        exclude:
+          - ${{ fromJson(inputs.wasm_exclude_swift_versions) }}
     container:
       image: ${{ (contains(matrix.swift_version, 'nightly') && 'swiftlang/swift') || 'swift' }}:${{ matrix.swift_version }}-${{ matrix.os_version }}
     steps:


### PR DESCRIPTION
This allows building a package with Embedded Swift SDK for Wasm. Additionally, `wasm_exclude_swift_versions` was added to allow exclusion of certain versions that don't have certain features supported.