### PR TITLE
Do not assume windows_build_command is a single line

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -45,8 +45,8 @@ jobs:
       windows_build_command: |
         mkdir MyPackage
         cd MyPackage
-        swift package init --type library
-        swift build
+        Invoke-Program swift package init --type library
+        Invoke-Program swift build
       enable_windows_docker: true
 
   tests_without_docker:
@@ -59,8 +59,8 @@ jobs:
       windows_build_command: |
         mkdir MyPackage
         cd MyPackage
-        swift package init --type library
-        swift build
+        Invoke-Program swift package init --type library
+        Invoke-Program swift build
       enable_windows_docker: false
 
   tests_macos:

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -102,7 +102,7 @@ on:
           Windows Command Prompt command to build and test the package.
           Note that Powershell does not automatically exit if a subcommand fails. The Invoke-Program utility is available to propagate non-zero exit codes.
           It is strongly encouraged to run all command using `Invoke-Program` unless you want to continue on error eg. `Invoke-Program git apply patch.diff` instead of `git apply patch.diff`.
-        default: "swift test"
+        default: "Invoke-Program swift test"
       macos_env_vars:
         description: "Newline separated list of environment variables"
         type: string
@@ -450,7 +450,7 @@ jobs:
           Invoke-Program swift test --version
           Invoke-Program cd $Source
           ${{ inputs.windows_pre_build_command }}
-          Invoke-Program ${{ inputs.windows_build_command }} ${{ (contains(matrix.swift_version, 'nightly') && inputs.swift_nightly_flags) || inputs.swift_flags }}
+          ${{ inputs.windows_build_command }} ${{ (contains(matrix.swift_version, 'nightly') && inputs.swift_nightly_flags) || inputs.swift_flags }}
           '@ >> $env:TEMP\test-script\run.ps1
       # Docker build
       - name: Docker Build / Test


### PR DESCRIPTION
`windows_build_command` was prefixed with a `Invoke-Program` to ensure we catch errors, but this then misses multiline commands. Move `Invoke-Program` up into the default command and then assume that it is passed if a non-default command is used.

Note that `$ErrorActionPreference = 'Stop'` is not an option here - it only stops for cmdlets, not native commands.
`$PSNativeCommandUseErrorActionPreference = $true` allows stopping on native commands too, but that was only introduced in PowerShell 7.3. windowsservercore-ltsc2022 has 5.1 by default (though we could install a newer if we wanted to).

Update PR testing in this repo to use `Invoke-Program` to then actually catch failures.