### PR TITLE
Support en dash character within copyright year range in license header checking script

### DIFF
--- a/.github/workflows/scripts/check-license-header.sh
+++ b/.github/workflows/scripts/check-license-header.sh
@@ -116,7 +116,7 @@ while IFS= read -r file_path; do
   file_header=$(head -n "${expected_file_header_linecount}" "${file_path}")
   normalized_file_header=$(
     echo "${file_header}" \
-    | sed -E -e 's/20[12][0123456789] ?- ?20[12][0123456789]/YEARS/' -e 's/20[12][0123456789]/YEARS/' \
+    | sed -E -e 's/20[12][0123456789] ?[-–] ?20[12][0123456789]/YEARS/' -e 's/20[12][0123456789]/YEARS/' \
   )
 
   if ! diff -u \


### PR DESCRIPTION
This is a small change to the script which implements the "License headers check" GitHub action, so that it accepts en dash characters (–, i.e. `–`) in addition to the simpler hyphen character (-, i.e. `-`).

Motivation: We often use en dash in copyright year ranges in swift-testing instead of hyphen.