### PR TITLE
set explicit permissions for GitHub workflows - all remaining workflows

### DIFF
--- a/.github/workflows/create_automerge_pr.yml
+++ b/.github/workflows/create_automerge_pr.yml
@@ -40,6 +40,10 @@ name: Create automerge PR
 #    types: [..., ready_for_review]
 # ```
 # Unfortunately this will also re-trigger testing evenon a normal user's PR (which may have already been tested), but skipping them causes the checks to reset so this is the best we can do for now.
+
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/performance_test.yml
+++ b/.github/workflows/performance_test.yml
@@ -1,5 +1,8 @@
 name: Performance test
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,5 +1,8 @@
 name: Pull request
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, reopened, synchronize]

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -1,5 +1,8 @@
 name: Swift Matrix
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
See https://github.com/swiftlang/github-workflows/issues/167

```
.github/workflows/create_automerge_pr.yml
.github/workflows/performance_test.yml
.github/workflows/pull_request.yml
.github/workflows/swift_package_test.yml
```

Note: `write` permissions were already accurately set at the job level according to best practices. In those cases, it was simply about adding `contents: read` at the very top to be future-proof, as per OpenSSF recommendations.