### PR TITLE
Increase timeout of API breakage check

### DIFF
--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ inputs.api_breakage_check_container_image }}
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The API breakage check has to build a project twice to detect the difference in API. This can easily hit the current timeout of 20 minutes for [larger projects](https://github.com/apple/swift-temporal-sdk/actions/runs/18406091287/job/52446247806). Increase the timeout to 40 minutes for now.