### PR TITLE
Fix build warnings in the workflow for iOS

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -134,7 +134,7 @@ on:
       ios_build_command:
         type: string
         description: "macOS command to build the package for iOS"
-        default: "xcrun swift build --build-tests --sdk \"$(xcrun --sdk iphoneos --show-sdk-path)\" --triple arm64-apple-ios"
+        default: "\"$(xcrun -f swift)\" build --build-tests --sdk \"$(xcrun --sdk iphoneos --show-sdk-path)\" --triple arm64-apple-ios"
       ios_build_timeout:
         type: number
         description: "The default step timeout in minutes"
@@ -307,7 +307,8 @@ jobs:
       - name: Select Xcode
         run: echo "DEVELOPER_DIR=/Applications/Xcode_${{ matrix.xcode_version }}.app" >> $GITHUB_ENV
       - name: Swift version
-        run: xcrun swift --version
+        run: |
+          "$(xcrun -f swift)" --version
       - name: Pre-build
         run: ${{ inputs.ios_pre_build_command }}
       - name: Build


### PR DESCRIPTION
IMHO, it would be better to use `$(xcrun -f swift)` ("find" mode) instead of `xcrun swift` ("run" mode).

`xcrun swift` is fine with packages that do not contain `executableTarget`, but it causes the following errors with packages that contain `executableTarget`:

```
clang: warning: using sysroot for 'MacOSX' but targeting 'iPhone'
[-Wincompatible-sysroot]
```

To prevent this, we can use `$(xcrun -f swift)` instead of `xcrun swift`.

Related discussion:
https://forums.swift.org/t/getting-incompatible-sysroot-warning-when-compiling-for-ios-with-sdk-and-target-set/80584

You can easily reproduce this issue by the following steps:

```shell
mkdir foo && cd foo
swift package init --type executable --name Foo
xcrun swift build --sdk "$(xcrun --sdk iphoneos --show-sdk-path)" --triple arm64-apple-ios
```