### PR TITLE
Update Android SDK build name to include NDK version

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -560,7 +560,7 @@ jobs:
             exit 1
           fi
           curl -s --retry 3 https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/install-and-build-with-sdk.sh | \
-          bash -s -- --android --flags="$BUILD_FLAGS" --build-command="${{ inputs.android_sdk_build_command }}" --android-sdk-triple="${{ inputs.sdk_triple }}" --android-ndk-version="${{ inputs.ndk_version }}" ${{ matrix.swift_version }}
+          bash -s -- --android --flags="$BUILD_FLAGS" --build-command="${{ inputs.android_sdk_build_command }}" --android-sdk-triple="${{ matrix.sdk_triple }}" --android-ndk-version="${{ matrix.ndk_version }}" ${{ matrix.swift_version }}
 
   windows-build:
     name: Windows (${{ matrix.swift_version }} - windows-2022)


### PR DESCRIPTION
This allows differentiating them when multiple NDKs are used.

As far as multiple triples, I think those should be handled within the workflow, rather than splitting off into new matrix entries (especially as we already have some multi-triple build capabilities in swiftpm for macOS now and could conceivably extend that to Android), but that's for another PR.