### PR TITLE
Always use the current version of the scripts (Linux + Wasm)

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -533,6 +533,10 @@ jobs:
         run: clang --version
       - name: Checkout repository
         uses: actions/checkout@v4
+        if: ${{ matrix.os_version != 'amazonlinux2' }}
+      - name: Checkout repository
+        uses: actions/checkout@v1
+        if: ${{ matrix.os_version == 'amazonlinux2' }}
       - name: Checkout swiftlang/github-workflows repository
         if: ${{ matrix.os_version != 'amazonlinux2' && github.repository != 'swiftlang/github-workflows' }}
         uses: actions/checkout@v4


### PR DESCRIPTION
This applies the changes previously made for Android to:

- Linux
- Linux Static SDK
- Wasm SDK
- Embedded Wasm SDK