### PR TITLE
Skip matrix jobs more cleanly

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -218,14 +218,13 @@ on:
 jobs:
   macos-build:
     name: macOS (Xcode ${{ matrix.xcode_version }} - ${{ matrix.os_version }} - ${{ matrix.arch }})
-    if: ${{ inputs.enable_macos_checks }}
     runs-on: [self-hosted, macos, "${{ matrix.os_version }}", "${{ matrix.arch }}"]
     strategy:
       fail-fast: false
       matrix:
-        xcode_version: ${{ fromJson(inputs.macos_xcode_versions) }}
-        os_version: ${{ fromJson(inputs.macos_versions) }}
-        arch: ${{ fromJson(inputs.macos_archs) }}
+        xcode_version: ${{ fromJson((inputs.enable_macos_checks && inputs.macos_xcode_versions) || '[]') }}
+        os_version: ${{ fromJson((inputs.enable_macos_checks && inputs.macos_versions) || '[]') }}
+        arch: ${{ fromJson((inputs.enable_macos_checks && inputs.macos_archs) || '[]') }}
         exclude:
           - ${{ fromJson(inputs.macos_exclude_xcode_versions) }}
     steps:
@@ -256,14 +255,13 @@ jobs:
 
   ios-build:
     name: iOS (Build Only, Xcode ${{ matrix.xcode_version }} - ${{ matrix.os_version }} - ${{ matrix.arch }})
-    if: ${{ inputs.enable_ios_checks }}
     runs-on: [self-hosted, macos, "${{ matrix.os_version }}", "${{ matrix.arch }}"]
     strategy:
       fail-fast: false
       matrix:
-        xcode_version: ${{ fromJson(inputs.ios_host_xcode_versions || inputs.macos_xcode_versions) }}
-        os_version: ${{ fromJson(inputs.ios_host_versions || inputs.macos_versions) }}
-        arch: ${{ fromJson(inputs.ios_host_archs || inputs.macos_archs) }}
+        xcode_version: ${{ fromJson((inputs.enable_ios_checks && (inputs.ios_host_xcode_versions || inputs.macos_xcode_versions)) || '[]') }}
+        os_version: ${{ fromJson((inputs.enable_ios_checks && (inputs.ios_host_versions || inputs.macos_versions)) || '[]') }}
+        arch: ${{ fromJson((inputs.enable_ios_checks && (inputs.ios_host_archs || inputs.macos_archs)) || '[]') }}
         exclude:
           - ${{ fromJson(inputs.ios_host_exclude_xcode_versions || inputs.macos_exclude_xcode_versions) }}
     steps:
@@ -292,13 +290,12 @@ jobs:
 
   linux-build:
     name: Linux (${{ matrix.swift_version }} - ${{ matrix.os_version }})
-    if: ${{ inputs.enable_linux_checks }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        swift_version: ${{ fromJson(inputs.linux_swift_versions) }}
-        os_version: ${{ fromJson(inputs.linux_os_versions) }}
+        swift_version: ${{ fromJson((inputs.enable_linux_checks && inputs.linux_swift_versions) || '[]') }}
+        os_version: ${{ fromJson((inputs.enable_linux_checks && inputs.linux_os_versions) || '[]') }}
         exclude:
           - ${{ fromJson(inputs.linux_exclude_swift_versions) }}
     container:
@@ -359,13 +356,12 @@ jobs:
 
   linux-static-sdk-build:
     name: Static Linux Swift SDK Build (${{ matrix.swift_version }} - ${{ matrix.os_version }})
-    if: ${{ inputs.enable_linux_static_sdk_build }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        swift_version: ${{ fromJson(inputs.linux_static_sdk_versions) }}
-        os_version: ${{ fromJson(inputs.linux_os_versions) }}
+        swift_version: ${{ fromJson((inputs.enable_linux_static_sdk_build && inputs.linux_static_sdk_versions) || '[]') }}
+        os_version: ${{ fromJson((inputs.enable_linux_static_sdk_build && inputs.linux_os_versions) || '[]') }}
         exclude:
           - ${{ fromJson(inputs.linux_static_sdk_exclude_swift_versions) }}
     container:
@@ -437,13 +433,12 @@ jobs:
 
   wasm-sdk-build:
     name: Swift SDK for Wasm Build (${{ matrix.swift_version }} - ${{ matrix.os_version }})
-    if: ${{ inputs.enable_wasm_sdk_build }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        swift_version: ${{ fromJson(inputs.wasm_sdk_versions) }}
-        os_version: ${{ fromJson(inputs.linux_os_versions) }}
+        swift_version: ${{ fromJson((inputs.enable_wasm_sdk_build && inputs.wasm_sdk_versions) || '[]') }}
+        os_version: ${{ fromJson((inputs.enable_wasm_sdk_build && inputs.linux_os_versions) || '[]') }}
         exclude:
           - ${{ fromJson(inputs.wasm_exclude_swift_versions) }}
     container:
@@ -515,13 +510,12 @@ jobs:
 
   embedded-wasm-sdk-build:
     name: Embedded Swift SDK for Wasm Build (${{ matrix.swift_version }} - ${{ matrix.os_version }})
-    if: ${{ inputs.enable_embedded_wasm_sdk_build }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        swift_version: ${{ fromJson(inputs.wasm_sdk_versions) }}
-        os_version: ${{ fromJson(inputs.linux_os_versions) }}
+        swift_version: ${{ fromJson((inputs.enable_embedded_wasm_sdk_build && inputs.wasm_sdk_versions) || '[]') }}
+        os_version: ${{ fromJson((inputs.enable_embedded_wasm_sdk_build && inputs.linux_os_versions) || '[]') }}
         exclude:
           - ${{ fromJson(inputs.wasm_exclude_swift_versions) }}
     container:
@@ -593,14 +587,13 @@ jobs:
 
   android-sdk-build:
     name: Swift SDK for Android Build (${{ matrix.swift_version }} - ${{ matrix.os_version }} - NDK ${{ matrix.ndk_version }})
-    if: ${{ inputs.enable_android_sdk_build }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        swift_version: ${{ fromJson(inputs.android_sdk_versions) }}
-        ndk_version: ${{ fromJson(inputs.android_ndk_versions) }}
-        os_version: ${{ fromJson(inputs.linux_os_versions) }}
+        swift_version: ${{ fromJson((inputs.enable_android_sdk_build && inputs.android_sdk_versions) || '[]') }}
+        ndk_version: ${{ fromJson((inputs.enable_android_sdk_build && inputs.android_ndk_versions) || '[]') }}
+        os_version: ${{ fromJson((inputs.enable_android_sdk_build && inputs.linux_os_versions) || '[]') }}
         exclude:
           - ${{ fromJson(inputs.android_exclude_swift_versions) }}
     container:
@@ -672,12 +665,11 @@ jobs:
 
   windows-build:
     name: Windows (${{ matrix.swift_version }} - windows-2022)
-    if: ${{ inputs.enable_windows_checks }}
     runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:
-        swift_version: ${{ fromJson(inputs.windows_swift_versions) }}
+        swift_version: ${{ fromJson((inputs.enable_windows_checks && inputs.windows_swift_versions) || '[]') }}
         exclude:
           - ${{ fromJson(inputs.windows_exclude_swift_versions) }}
     steps:


### PR DESCRIPTION
Now disabled jobs will just disappear entirely, rather than appear with confusing unexpanded placeholders.