### PR TITLE
Switch shellcheck soundness check to a lighter weight image

### DIFF
--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -65,8 +65,8 @@ on:
         default: true
       shell_check_container_image:
         type: string
-        description: "Container image for the shell check job. Defaults to latest Swift Ubuntu image."
-        default: "swift:6.2-noble"
+        description: "Container image for the shell check job. Defaults to latest Ubuntu 24.04 Noble image."
+        default: "ubuntu:noble"
       yamllint_check_enabled:
         type: boolean
         description: "Boolean to enable the YAML lint check job. Defaults to true."
@@ -293,6 +293,8 @@ jobs:
       image: ${{ inputs.shell_check_container_image }}
     timeout-minutes: 5
     steps:
+      - name: Install git
+        run: which git || (apt -q update && apt -yq install git)
       - name: Checkout repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This just installs and runs shellcheck. It doesn't need a 1 GB Swift toolchain image; in contrast the noble image is 30 MB. This makes shellcheck run faster and doesn't waste resources.