### PR TITLE
Add a test package for CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,9 +17,7 @@ jobs:
       enable_macos_checks: false
       enable_windows_checks: false
       wasm_sdk_pre_build_command: |
-        mkdir MyPackage
-        cd MyPackage
-        swift package init --type library
+        cd tests/TestPackage
       enable_embedded_wasm_sdk_build: true
 
   tests_with_docker:
@@ -29,32 +27,22 @@ jobs:
       # Linux
       linux_os_versions: '["jammy", "rhel-ubi9", "amazonlinux2"]'
       linux_build_command: |
-        mkdir MyPackage
-        cd MyPackage
-        swift package init --type library
+        cd tests/TestPackage
         swift build
       linux_static_sdk_pre_build_command: |
-        mkdir MyPackage
-        cd MyPackage
-        swift package init --type library
+        cd tests/TestPackage
       enable_linux_static_sdk_build: true
       # Wasm
       wasm_sdk_pre_build_command: |
-        mkdir MyPackage
-        cd MyPackage
-        swift package init --type library
+        cd tests/TestPackage
       enable_wasm_sdk_build: true
       # Android
       android_sdk_pre_build_command: |
-        mkdir MyPackage
-        cd MyPackage
-        swift package init --type library
+        cd tests/TestPackage
       enable_android_sdk_build: true
       # Windows
       windows_build_command: |
-        mkdir MyPackage
-        cd MyPackage
-        Invoke-Program swift package init --type library
+        cd tests/TestPackage
         Invoke-Program swift build
       enable_windows_docker: true
 
@@ -66,15 +54,11 @@ jobs:
       enable_linux_checks: false
       # Android
       android_sdk_pre_build_command: |
-        mkdir MyPackage
-        cd MyPackage
-        swift package init --type library
+        cd tests/TestPackage
       enable_android_sdk_build: true
       # Windows
       windows_build_command: |
-        mkdir MyPackage
-        cd MyPackage
-        Invoke-Program swift package init --type library
+        cd tests/TestPackage
         Invoke-Program swift build
       enable_windows_docker: false
 
@@ -87,9 +71,7 @@ jobs:
       # macOS
       enable_macos_checks: true
       macos_build_command: |
-        mkdir MyPackage
-        cd MyPackage
-        xcrun swift package init --type library
+        cd tests/TestPackage
         xcrun swift build
 
   build_tests_ios:
@@ -100,9 +82,9 @@ jobs:
       enable_windows_checks: false
       # iOS
       enable_ios_checks: true
-      ios_pre_build_command: |
-        pwd
-        xcrun swift package init --type library
+      ios_build_command: |
+        cd tests/TestPackage
+        xcodebuild -quiet -scheme TestPackage-Package -destination "generic/platform=ios" build
 
   soundness:
     name: Soundness

--- a/.licenseignore
+++ b/.licenseignore
@@ -3,3 +3,5 @@
 CODEOWNERS
 LICENSE.txt
 README.md
+**/Package.swift
+**/Package@swift-*

--- a/tests/TestPackage/Package.swift
+++ b/tests/TestPackage/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.1
+
+import PackageDescription
+
+let package = Package(
+  name: "TestPackage",
+  targets: [
+    .target(
+      name: "Target1"
+    ),
+    .target(
+      name: "Target2",
+      dependencies: [
+        "Target1"
+      ]
+    ),
+    .testTarget(
+      name: "Target1Tests",
+      dependencies: ["Target1"]
+    ),
+  ]
+)

--- a/tests/TestPackage/Package@swift-5.10.swift
+++ b/tests/TestPackage/Package@swift-5.10.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.10
+
+import PackageDescription
+
+let package = Package(
+  name: "TestPackage",
+  targets: [
+    .target(
+      name: "Target1"
+    ),
+    .target(
+      name: "Target2",
+      dependencies: [
+        "Target1"
+      ]
+    ),
+    .testTarget(
+      name: "Target1Tests",
+      dependencies: ["Target1"]
+    ),
+  ]
+)

--- a/tests/TestPackage/Package@swift-5.9.swift
+++ b/tests/TestPackage/Package@swift-5.9.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+  name: "TestPackage",
+  targets: [
+    .target(
+      name: "Target1"
+    ),
+    .target(
+      name: "Target2",
+      dependencies: [
+        "Target1"
+      ]
+    ),
+    .testTarget(
+      name: "Target1Tests",
+      dependencies: ["Target1"]
+    ),
+  ]
+)

--- a/tests/TestPackage/Package@swift-6.0.swift
+++ b/tests/TestPackage/Package@swift-6.0.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+  name: "TestPackage",
+  targets: [
+    .target(
+      name: "Target1"
+    ),
+    .target(
+      name: "Target2",
+      dependencies: [
+        "Target1"
+      ]
+    ),
+    .testTarget(
+      name: "Target1Tests",
+      dependencies: ["Target1"]
+    ),
+  ]
+)

--- a/tests/TestPackage/Sources/Target1/Target1.swift
+++ b/tests/TestPackage/Sources/Target1/Target1.swift
@@ -1,0 +1,13 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public func foo() {}

--- a/tests/TestPackage/Sources/Target2/Target2.swift
+++ b/tests/TestPackage/Sources/Target2/Target2.swift
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Target1
+
+public func bar() {
+  foo()
+}

--- a/tests/TestPackage/Tests/Target1Tests/Target1Tests.swift
+++ b/tests/TestPackage/Tests/Target1Tests/Target1Tests.swift
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Target1
+import Testing
+
+@Test func example() async throws {
+  foo()
+}


### PR DESCRIPTION
We currently have setup the workflows in this repository to test the various reusable workflows. The workflows that require a Swift package have created their own package as a pre-build command. While this worked so far it limits the kinds of packages that we can setup. This PR is committing a Swift Package to the `tests` folder which we can shape more complicated ways to test the various workflows better.