### PR TITLE
Install Python 3.10 in dockerless Windows builds

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -736,7 +736,4 @@ jobs:
       - name: Build / Test
         timeout-minutes: 60
         if: ${{ !inputs.enable_windows_docker }}
-        run: |
-          Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
-          RefreshEnv
-          powershell.exe -NoLogo -File $env:TEMP\test-script\run.ps1; exit $LastExitCode
+        run: powershell.exe -NoLogo -File $env:TEMP\test-script\run.ps1; exit $LastExitCode


### PR DESCRIPTION
LLDB in Swift 6.2.1+ requires Python 3.10 which we can install using `actions/setup-python` in dockerless Windows. This also required removing the call to `RefreshEnv` which was previously added as a workaround to refresh the Swift installer's environment variables. Instead, the `install-swift.ps1` script will now correctly update the job's environment variables so that `RefreshEnv` isn't necessary anymore.