### PR TITLE
Fix sdk name in swiftpm

### DIFF
--- a/.github/workflows/scripts/install-and-build-with-sdk.sh
+++ b/.github/workflows/scripts/install-and-build-with-sdk.sh
@@ -62,7 +62,7 @@ swift_sdk_install_with_retry() {
     # Extract SDK name from URL for checking if already installed
     local sdk_filename
     sdk_filename=$(basename "$sdk_url")
-    local sdk_name="${sdk_filename%.tar.gz}"
+    local sdk_name="${sdk_filename%.artifactbundle.tar.gz}"
 
     while [ $attempt -le $SDK_INSTALL_MAX_RETRIES ]; do
         if [ $attempt -gt 1 ]; then


### PR DESCRIPTION
We uninstall the partially installed SDK if an error occurs, and we need the SDK name to be correct when checking for a partially installed SDK. This fixes it