### PR TITLE
Fix error annotations

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -230,14 +230,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        matrix_enabled:
+          - ${{ inputs.enable_macos_checks }}
         xcode_version: ${{ fromJson(inputs.macos_xcode_versions) }}
         os_version: ${{ fromJson(inputs.macos_versions) }}
         arch: ${{ fromJson(inputs.macos_archs) }}
         exclude:
           - ${{ fromJson(inputs.macos_exclude_xcode_versions) }}
-          - ${{ fromJson((!inputs.enable_macos_checks && inputs.macos_xcode_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_macos_checks && inputs.macos_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_macos_checks && inputs.macos_archs) || '[]') }}
+          - matrix_enabled: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -270,14 +270,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        matrix_enabled:
+          - ${{ inputs.enable_ios_checks }}
         xcode_version: ${{ fromJson(inputs.ios_host_xcode_versions || inputs.macos_xcode_versions) }}
         os_version: ${{ fromJson(inputs.ios_host_versions || inputs.macos_versions) }}
         arch: ${{ fromJson(inputs.ios_host_archs || inputs.macos_archs) }}
         exclude:
           - ${{ fromJson(inputs.ios_host_exclude_xcode_versions || inputs.macos_exclude_xcode_versions) }}
-          - ${{ fromJson((!inputs.enable_ios_checks && (inputs.ios_host_xcode_versions || inputs.macos_xcode_versions)) || '[]') }}
-          - ${{ fromJson((!inputs.enable_ios_checks && (inputs.ios_host_versions || inputs.macos_versions)) || '[]') }}
-          - ${{ fromJson((!inputs.enable_ios_checks && (inputs.ios_host_archs || inputs.macos_archs)) || '[]') }}
+          - matrix_enabled: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -308,6 +308,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        matrix_enabled:
+          - ${{ inputs.enable_linux_checks }}
         swift_version: ${{ fromJson(inputs.linux_swift_versions) }}
         os_version: ${{ fromJson(inputs.linux_os_versions) }}
         arch: ${{ fromJson(inputs.linux_host_archs) }}
@@ -322,9 +324,7 @@ jobs:
           }}
         exclude:
           - ${{ fromJson(inputs.linux_exclude_swift_versions) }}
-          - ${{ fromJson((!inputs.enable_linux_checks && inputs.linux_swift_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_linux_checks && inputs.linux_os_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_linux_checks && inputs.linux_host_archs) || '[]') }}
+          - matrix_enabled: false
           - arch: x86_64
             runner: ubuntu-24.04-arm
           - arch: aarch64
@@ -390,6 +390,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        matrix_enabled:
+          - ${{ inputs.enable_linux_static_sdk_build }}
         swift_version: ${{ fromJson(inputs.linux_static_sdk_versions) }}
         os_version: ${{ fromJson(inputs.linux_os_versions) }}
         arch: ${{ fromJson(inputs.linux_host_archs) }}
@@ -404,9 +406,7 @@ jobs:
           }}
         exclude:
           - ${{ fromJson(inputs.linux_static_sdk_exclude_swift_versions) }}
-          - ${{ fromJson((!inputs.enable_linux_static_sdk_build && inputs.linux_static_sdk_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_linux_static_sdk_build && inputs.linux_os_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_linux_static_sdk_build && inputs.linux_host_archs) || '[]') }}
+          - matrix_enabled: false
           - arch: x86_64
             runner: ubuntu-24.04-arm
           - arch: aarch64
@@ -467,16 +467,19 @@ jobs:
 
   wasm-sdk-build:
     name: Swift SDK for Wasm Build (${{ matrix.swift_version }} - ${{ matrix.os_version }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
+        matrix_enabled:
+          - ${{ inputs.enable_wasm_sdk_build }}
         swift_version: ${{ fromJson(inputs.wasm_sdk_versions) }}
         os_version: ${{ fromJson(inputs.linux_os_versions) }}
+        runner:
+          - ubuntu-latest
         exclude:
           - ${{ fromJson(inputs.wasm_exclude_swift_versions) }}
-          - ${{ fromJson((!inputs.enable_wasm_sdk_build && inputs.wasm_sdk_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_wasm_sdk_build && inputs.linux_os_versions) || '[]') }}
+          - matrix_enabled: false
     container:
       image: ${{ (contains(matrix.swift_version, 'nightly') && 'swiftlang/swift') || 'swift' }}:${{ matrix.swift_version }}-${{ matrix.os_version }}
     steps:
@@ -533,16 +536,19 @@ jobs:
 
   embedded-wasm-sdk-build:
     name: Embedded Swift SDK for Wasm Build (${{ matrix.swift_version }} - ${{ matrix.os_version }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
+        matrix_enabled:
+          - ${{ inputs.enable_embedded_wasm_sdk_build }}
+        runner:
+          - ubuntu-latest
         swift_version: ${{ fromJson(inputs.wasm_sdk_versions) }}
         os_version: ${{ fromJson(inputs.linux_os_versions) }}
         exclude:
           - ${{ fromJson(inputs.wasm_exclude_swift_versions) }}
-          - ${{ fromJson((!inputs.enable_embedded_wasm_sdk_build && inputs.wasm_sdk_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_embedded_wasm_sdk_build && inputs.linux_os_versions) || '[]') }}
+          - matrix_enabled: false
     container:
       image: ${{ (contains(matrix.swift_version, 'nightly') && 'swiftlang/swift') || 'swift' }}:${{ matrix.swift_version }}-${{ matrix.os_version }}
     steps:
@@ -599,18 +605,20 @@ jobs:
 
   android-sdk-build:
     name: Swift SDK for Android Build (${{ matrix.swift_version }} - ${{ matrix.os_version }} - NDK ${{ matrix.ndk_version }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
+        matrix_enabled:
+          - ${{ inputs.enable_android_sdk_build }}
+        runner:
+          - ubuntu-latest
         swift_version: ${{ fromJson(inputs.android_sdk_versions) }}
         ndk_version: ${{ fromJson(inputs.android_ndk_versions) }}
         os_version: ${{ fromJson(inputs.linux_os_versions) }}
         exclude:
           - ${{ fromJson(inputs.android_exclude_swift_versions) }}
-          - ${{ fromJson((!inputs.enable_android_sdk_build && inputs.android_sdk_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_android_sdk_build && inputs.android_ndk_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_android_sdk_build && inputs.linux_os_versions) || '[]') }}
+          - matrix_enabled: false
     container:
       image: ${{ (contains(matrix.swift_version, 'nightly') && 'swiftlang/swift') || 'swift' }}:${{ matrix.swift_version }}-${{ matrix.os_version }}
     steps:
@@ -671,12 +679,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        matrix_enabled:
+          - ${{ inputs.enable_windows_checks }}
         swift_version: ${{ fromJson(inputs.windows_swift_versions) }}
         os_version: ${{ fromJson(inputs.windows_os_versions) }}
         exclude:
           - ${{ fromJson(inputs.windows_exclude_swift_versions) }}
-          - ${{ fromJson((!inputs.enable_windows_checks && inputs.windows_swift_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_windows_checks && inputs.windows_os_versions) || '[]') }}
+          - matrix_enabled: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The previous method of excluding matrix entries results in complaints annotating the action run (even though the matrix produces the correct entries and _works_), but this noise gets in the way of real errors and may be bothersome.

Use a new technique (which amusingly is even simpler) to skip the whole matrix when the enabled flag is off for a group of builds.