### PR TITLE
Introduce a macOS DocC soundness check

### DIFF
--- a/.github/workflows/scripts/check-docs.sh
+++ b/.github/workflows/scripts/check-docs.sh
@@ -3,7 +3,7 @@
 ##
 ## This source file is part of the Swift.org open source project
 ##
-## Copyright (c) 2024 Apple Inc. and the Swift project authors
+## Copyright (c) 2025 Apple Inc. and the Swift project authors
 ## Licensed under Apache License v2.0 with Runtime Library Exception
 ##
 ## See https://swift.org/LICENSE.txt for license information
@@ -23,7 +23,10 @@ if [ ! -f .spi.yml ]; then
 fi
 
 if ! command -v yq &> /dev/null; then
-  apt -q update && apt -yq install yq
+  case "$(uname -s)" in
+  Darwin*) echo brew install yq;;
+  Linux*) echo apt -q update && apt -yq install yq;;
+  esac
 fi
 
 package_files=$(find . -maxdepth 1 -name 'Package*.swift')

--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -31,6 +31,26 @@ on:
         type: string
         description: "Additional arguments that should be passed to docc"
         default: ""
+      docs_check_macos_enabled:
+        type: boolean
+        description: "Boolean to enable the macOS docs check job. Defaults to false."
+        default: false
+      docs_check_macos_version:
+        type: string
+        description: "macOS version for the macOS docs check job."
+        default: "sequoia"
+      docs_check_macos_arch:
+        type: string
+        description: "macOS arch for the macOS docs check job."
+        default: "ARM64"
+      docs_check_macos_xcode_version:
+        type: string
+        description: "Xcode version for the macOS docs check job."
+        default: "26.0"
+      docs_check_macos_additional_arguments:
+        type: string
+        description: "Additional arguments that should be passed to docc for the macOS docs check job."
+        default: ""
       unacceptable_language_check_enabled:
         type: boolean
         description: "Boolean to enable the acceptable language check job. Defaults to true."
@@ -162,6 +182,42 @@ jobs:
       - name: Run documentation check
         env:
           ADDITIONAL_DOCC_ARGUMENTS: ${{ inputs.docs_check_additional_arguments }}
+        run: ${{ steps.script_path.outputs.root }}/.github/workflows/scripts/check-docs.sh
+
+  docs-check-macos:
+    name: Documentation check (macOS)
+    if: ${{ inputs.docs_check_macos_enabled }}
+    runs-on: [self-hosted, macos, "${{ inputs.docs_check_macos_version }}", "${{ inputs.docs_check_macos_arch }}"]
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          submodules: true
+      - name: Checkout swiftlang/github-workflows repository
+        if: ${{ github.repository != 'swiftlang/github-workflows' }}
+        uses: actions/checkout@v4
+        with:
+          repository: swiftlang/github-workflows
+          path: github-workflows
+      - name: Determine script-root path
+        id: script_path
+        run: |
+          if [ "${{ github.repository }}" = "swiftlang/github-workflows" ]; then
+            echo "root=$GITHUB_WORKSPACE" >> $GITHUB_OUTPUT
+          else
+            echo "root=$GITHUB_WORKSPACE/github-workflows" >> $GITHUB_OUTPUT
+          fi
+      - name: Select Xcode
+        run: echo "DEVELOPER_DIR=/Applications/Xcode_${{ inputs.docs_check_macos_xcode_version }}.app" >> $GITHUB_ENV
+      - name: Swift version
+        run: xcrun swift --version
+      - name: Clang version
+        run: xcrun clang --version
+      - name: Run documentation check
+        env:
+          ADDITIONAL_DOCC_ARGUMENTS: ${{ inputs.docs_check_macos_additional_arguments }}
         run: ${{ steps.script_path.outputs.root }}/.github/workflows/scripts/check-docs.sh
 
   unacceptable-language-check:


### PR DESCRIPTION
This introduces a variant of the "Documentation Check" (i.e. `docs-check`) job within [`soundness.yml`](https://github.com/swiftlang/github-workflows/blob/main/.github/workflows/soundness.yml) which runs the same check on macOS instead of Linux.

This new job is disabled by default, but can be enabled via the new `docs_check_macos_enabled` input setting.

**Motivation**: Some packages (such as Swift Testing) are unable to use the current documentation check job because they encounter issues when attempting to build documentation on platforms other than macOS. (In Swift Testing's case, the problems relate to its use of Swift cross-import overlays and cross-module references.) Those issues will be tracked separately, but cannot always be readily worked around. Additionally, having a macOS job which builds documentation helps ensure the documentation can be built successfully at-desk when developing on macOS.