### PR TITLE
Fix error installing yq tool in check-docs soundness script

### DIFF
--- a/.github/workflows/scripts/check-docs.sh
+++ b/.github/workflows/scripts/check-docs.sh
@@ -24,8 +24,8 @@ fi
 
 if ! command -v yq &> /dev/null; then
   case "$(uname -s)" in
-  Darwin*) echo brew install yq;;
-  Linux*) echo apt -q update && apt -yq install yq;;
+  Darwin*) brew install yq;;
+  Linux*) apt -q update && apt -yq install yq;;
   esac
 fi
 


### PR DESCRIPTION
This fixes a regression from my recent PR #216, there were `echo` statements left in for debugging which should have been removed.