### PR TITLE
Fix crash in emulator launch in android-emulator-tests.sh

### DIFF
--- a/.github/workflows/scripts/android/android-emulator-tests.sh
+++ b/.github/workflows/scripts/android/android-emulator-tests.sh
@@ -110,9 +110,7 @@ while true; do
     if [ "$BOOT_STATUS" == "1" ]; then
         log "Emulator is ready"
         break;
-    fi
-
-    if [ "$EMULATOR_CHECK_SECONDS_ELAPSED" -ge "$ANDROID_EMULATOR_TIMEOUT" ]; then
+    elif [ "$EMULATOR_CHECK_SECONDS_ELAPSED" -ge "$ANDROID_EMULATOR_TIMEOUT" ]; then
         fatal "Timeout reached ($ANDROID_EMULATOR_TIMEOUT seconds). Aborting."
     fi
 done


### PR DESCRIPTION
While waiting for the Android emulator to start up, we poll it with `adb wait-for-any-device`. This seems to crash sometimes (e.g, in this [workflow run](https://github.com/apple/swift-configuration/actions/runs/20895685803/job/60043318089) for https://github.com/apple/swift-configuration/pull/140) with:

```
USER_INFO    | Emulator is performing a full startup. This may take upto two minutes, or more.
WARNING      | Failed to process .ini file /home/runner/.android/emu-update-last-check.ini for reading.
timeout: the monitored command dumped core
/home/runner/work/swift-configuration/swift-configuration/github-workflows/.github/workflows/scripts/android/android-emulator-tests.sh: line 99:  6236 Aborted                 timeout "${ANDROID_EMULATOR_TIMEOUT}" adb wait-for-any-device
WARNING      | Failed to process .ini file /home/runner/.android/emu-update-last-check.ini for reading.
```

This PR introduces periodic polling with `adb shell getprop sys.boot_completed` on the theory that the emulator startup process is conflicting with the `adb` command.

An example of the output should now look like:

```
** Waiting for Android emulator startup (5)
* daemon not running; starting now at tcp:5037
* daemon started successfully
adb: device offline
** Waiting for Android emulator startup (10)
** Waiting for Android emulator startup (15)
** Waiting for Android emulator startup (20)
** Waiting for Android emulator startup (25)
** Waiting for Android emulator startup (30)
** Waiting for Android emulator startup (35)
INFO         | Boot completed in 38815 ms
INFO         | Increasing screen off timeout, logcat buffer size to 2M.
** Waiting for Android emulator startup (40)
** Emulator is ready
** Prepare Swift test package
```


CC: @finagolfin
