### PR TITLE
Install Python 3.9 on 6.1 and lower

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -795,4 +795,3 @@ jobs:
         timeout-minutes: 60
         if: ${{ !inputs.enable_windows_docker }}
         run: powershell.exe -NoLogo -File $env:TEMP\test-script\run.ps1; exit $LastExitCode
-


### PR DESCRIPTION
The underlying Windows image has been updated to remove Python 3.9. Swift toolchains version 6.1 and lower require Python 3.9. Install it for these toolchains, and continue to install 3.10 for toolchains > 6.1.