### PR TITLE
Add PR Dependency check workflow

### DIFF
--- a/.github/workflows/github_actions_dependencies.yml
+++ b/.github/workflows/github_actions_dependencies.yml
@@ -1,0 +1,17 @@
+name: Check for Dependencies in PR
+
+on:
+  workflow_call:
+
+permissions:
+  issues: read
+  pull-requests: read
+
+jobs:
+  check_dependencies:
+    runs-on: ubuntu-latest
+    name: "Check GitHub Actions Dependencies"
+    steps:
+      - uses: gregsdennis/dependencies-action@v1.4.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,15 +2,22 @@ name: Pull request
 
 permissions:
   contents: read
+  issues: read
+  pull-requests: read
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, edited, reopened, labeled, unlabeled, synchronize]
 
 jobs:
+  github_actiion_pr_dependency_check:
+    name: GitHub Action Dependency Check
+    uses: ./.github/workflows/github_actions_dependencies.yml
+
   tests_with_docker_embedded_swift:
     name: Test Embedded Swift SDKs
     uses: ./.github/workflows/swift_package_test.yml
+    if: ${{ github.event_name == 'opened' || github.event_name == 'reopened' || github.event_name == 'synchronize' }}
     with:
       # Wasm
       enable_linux_checks: false
@@ -23,6 +30,7 @@ jobs:
   tests_with_docker:
     name: Test with Docker
     uses: ./.github/workflows/swift_package_test.yml
+    if: ${{ github.event_name == 'opened' || github.event_name == 'reopened' || github.event_name == 'synchronize' }}
     with:
       # Linux
       linux_os_versions: '["jammy", "rhel-ubi9", "amazonlinux2"]'
@@ -46,6 +54,7 @@ jobs:
   tests_without_docker:
     name: Test without Docker
     uses: ./.github/workflows/swift_package_test.yml
+    if: ${{ github.event_name == 'opened' || github.event_name == 'reopened' || github.event_name == 'synchronize' }}
     with:
       # Skip Linux which doesn't currently support docker-less workflow
       enable_linux_checks: false
@@ -67,6 +76,7 @@ jobs:
   tests_macos:
     name: Test
     uses: ./.github/workflows/swift_package_test.yml
+    if: ${{ github.event_name == 'opened' || github.event_name == 'reopened' || github.event_name == 'synchronize' }}
     with:
       enable_linux_checks: false
       enable_windows_checks: false
@@ -79,6 +89,7 @@ jobs:
   build_tests_ios:
     name: Build iOS Tests
     uses: ./.github/workflows/swift_package_test.yml
+    if: ${{ github.event_name == 'opened' || github.event_name == 'reopened' || github.event_name == 'synchronize' }}
     with:
       enable_linux_checks: false
       enable_windows_checks: false
@@ -91,6 +102,7 @@ jobs:
   soundness:
     name: Soundness
     uses: ./.github/workflows/soundness.yml
+    if: ${{ github.event_name == 'opened' || github.event_name == 'reopened' || github.event_name == 'synchronize' }}
     with:
       api_breakage_check_enabled: false
       license_header_check_project_name: "Swift.org"

--- a/docs/pr-dependency-workflow.md
+++ b/docs/pr-dependency-workflow.md
@@ -1,0 +1,33 @@
+# PR Dependency Workflow Documentation
+
+## Overview
+
+The [`github_actions_dependencies.yml`](.github/workflows/github_actions_dependencies.yml) workflow uses [a third party GitHub action](https://github.com/marketplace/actions/pr-dependency-check) to enforce PR dependencies.
+
+At the time of writing, the GitHub action supported the following styles, for both issues and PRs.:
+
+- Quick Link: `#5`
+- Partial Link: `gregsdennis/dependencies-action#5`
+- Partial URL: `gregsdennis/dependencies-action/pull/5`
+- Full URL: `https://github.com/gregsdennis/dependencies-action/pull/5`
+- Markdown: `[markdown link](https://github.com/gregsdennis/dependencies-action/pull/5)`
+
+## Usage
+
+Add the following to a `.yaml` file in your `.github/workflows` directory:
+
+```
+name: Check for GitHub Actions Dependencies in PR
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, labeled, unlabeled, synchronize]
+
+permissions:
+  issues: read
+  pull-requests: read
+
+jobs:
+  check_dependencies:
+     uses: swiftlang/github-workflows/.github/workflows/github_actions_dependencies.yml.yml@<to-be-updated>
+```


### PR DESCRIPTION
While working on a project, I tend to build one PR on top of another.    And although The later PR can be merged and include all the child PR, it's not ideal as it can lead to the "parent" PR being closed without having any references to approval - as the approvals were given in a child PR.

Sometimes SwiftPM PR's are depend on a change in https://github.com/swiftlang/swift-build, or even changes in https://github.com/swiftlang/swift

Here's are examples of the two scenarios:
- https://github.com/swiftlang/swift-package-manager/pull/9039
- https://github.com/swiftlang/swift-package-manager/pull/9417
- https://github.com/swiftlang/swift-package-manager/pull/8092