### PR TITLE
Revert the matrix skipping changes

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -242,6 +242,7 @@ on:
 jobs:
   macos-build:
     name: macOS (Xcode ${{ matrix.xcode_version }} - ${{ matrix.os_version }} - ${{ matrix.arch }})
+    if: ${{ inputs.enable_macos_checks }}
     runs-on: [self-hosted, macos, "${{ matrix.os_version }}", "${{ matrix.arch }}"]
     strategy:
       fail-fast: false
@@ -251,9 +252,6 @@ jobs:
         arch: ${{ fromJson(inputs.macos_archs) }}
         exclude:
           - ${{ fromJson(inputs.macos_exclude_xcode_versions) }}
-          - ${{ fromJson((!inputs.enable_macos_checks && inputs.macos_xcode_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_macos_checks && inputs.macos_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_macos_checks && inputs.macos_archs) || '[]') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -282,6 +280,7 @@ jobs:
 
   ios-build:
     name: iOS (Build Only, Xcode ${{ matrix.xcode_version }} - ${{ matrix.os_version }} - ${{ matrix.arch }})
+    if: ${{ inputs.enable_ios_checks }}
     runs-on: [self-hosted, macos, "${{ matrix.os_version }}", "${{ matrix.arch }}"]
     strategy:
       fail-fast: false
@@ -291,9 +290,6 @@ jobs:
         arch: ${{ fromJson(inputs.ios_host_archs || inputs.macos_archs) }}
         exclude:
           - ${{ fromJson(inputs.ios_host_exclude_xcode_versions || inputs.macos_exclude_xcode_versions) }}
-          - ${{ fromJson((!inputs.enable_ios_checks && (inputs.ios_host_xcode_versions || inputs.macos_xcode_versions)) || '[]') }}
-          - ${{ fromJson((!inputs.enable_ios_checks && (inputs.ios_host_versions || inputs.macos_versions)) || '[]') }}
-          - ${{ fromJson((!inputs.enable_ios_checks && (inputs.ios_host_archs || inputs.macos_archs)) || '[]') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -320,6 +316,7 @@ jobs:
 
   linux-build:
     name: Linux (${{ matrix.swift_version }} - ${{ matrix.os_version }} - ${{ matrix.arch }})
+    if: ${{ inputs.enable_linux_checks }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -338,9 +335,6 @@ jobs:
           }}
         exclude:
           - ${{ fromJson(inputs.linux_exclude_swift_versions) }}
-          - ${{ fromJson((!inputs.enable_linux_checks && inputs.linux_swift_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_linux_checks && inputs.linux_os_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_linux_checks && inputs.linux_host_archs) || '[]') }}
           - arch: x86_64
             runner: ubuntu-24.04-arm
           - arch: aarch64
@@ -402,6 +396,7 @@ jobs:
 
   linux-static-sdk-build:
     name: Static Linux Swift SDK Build (${{ matrix.swift_version }} - ${{ matrix.os_version }} - ${{ matrix.arch }})
+    if: ${{ inputs.enable_linux_static_sdk_build }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -420,9 +415,6 @@ jobs:
           }}
         exclude:
           - ${{ fromJson(inputs.linux_static_sdk_exclude_swift_versions) }}
-          - ${{ fromJson((!inputs.enable_linux_static_sdk_build && inputs.linux_static_sdk_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_linux_static_sdk_build && inputs.linux_os_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_linux_static_sdk_build && inputs.linux_host_archs) || '[]') }}
           - arch: x86_64
             runner: ubuntu-24.04-arm
           - arch: aarch64
@@ -483,6 +475,7 @@ jobs:
 
   wasm-sdk-build:
     name: Swift SDK for Wasm Build (${{ matrix.swift_version }} - ${{ matrix.os_version }})
+    if: ${{ inputs.enable_wasm_sdk_build }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -491,8 +484,6 @@ jobs:
         os_version: ${{ fromJson(inputs.linux_os_versions) }}
         exclude:
           - ${{ fromJson(inputs.wasm_exclude_swift_versions) }}
-          - ${{ fromJson((!inputs.enable_wasm_sdk_build && inputs.wasm_sdk_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_wasm_sdk_build && inputs.linux_os_versions) || '[]') }}
     container:
       image: ${{ (contains(matrix.swift_version, 'nightly') && 'swiftlang/swift') || 'swift' }}:${{ matrix.swift_version }}-${{ matrix.os_version }}
     steps:
@@ -549,6 +540,7 @@ jobs:
 
   embedded-wasm-sdk-build:
     name: Embedded Swift SDK for Wasm Build (${{ matrix.swift_version }} - ${{ matrix.os_version }})
+    if: ${{ inputs.enable_embedded_wasm_sdk_build }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -557,8 +549,6 @@ jobs:
         os_version: ${{ fromJson(inputs.linux_os_versions) }}
         exclude:
           - ${{ fromJson(inputs.wasm_exclude_swift_versions) }}
-          - ${{ fromJson((!inputs.enable_embedded_wasm_sdk_build && inputs.wasm_sdk_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_embedded_wasm_sdk_build && inputs.linux_os_versions) || '[]') }}
     container:
       image: ${{ (contains(matrix.swift_version, 'nightly') && 'swiftlang/swift') || 'swift' }}:${{ matrix.swift_version }}-${{ matrix.os_version }}
     steps:
@@ -615,6 +605,7 @@ jobs:
 
   android-sdk-build:
     name: Swift SDK for Android Build (${{ matrix.swift_version }} - NDK ${{ matrix.ndk_version }})
+    if: ${{ inputs.enable_android_sdk_build }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -623,8 +614,6 @@ jobs:
         ndk_version: ${{ fromJson(inputs.android_ndk_versions) }}
         exclude:
           - ${{ fromJson(inputs.android_exclude_swift_versions) }}
-          - ${{ fromJson((!(inputs.enable_android_sdk_build || inputs.enable_android_sdk_checks) && inputs.android_sdk_versions) || '[]') }}
-          - ${{ fromJson((!(inputs.enable_android_sdk_build || inputs.enable_android_sdk_checks) && inputs.android_ndk_versions) || '[]') }}
     steps:
       - name: Swift version
         run: swift --version
@@ -686,6 +675,7 @@ jobs:
 
   windows-build:
     name: Windows (${{ matrix.swift_version }} - ${{ matrix.os_version }})
+    if: ${{ inputs.enable_windows_checks }}
     runs-on: ${{ matrix.os_version }}
     strategy:
       fail-fast: false
@@ -694,8 +684,6 @@ jobs:
         os_version: ${{ fromJson(inputs.windows_os_versions) }}
         exclude:
           - ${{ fromJson(inputs.windows_exclude_swift_versions) }}
-          - ${{ fromJson((!inputs.enable_windows_checks && inputs.windows_swift_versions) || '[]') }}
-          - ${{ fromJson((!inputs.enable_windows_checks && inputs.windows_os_versions) || '[]') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The current technique results in error annotations in the actions UI and build badges to be red, despite appearing to otherwise work. It seems that GitHub Actions truly has no way to prevent the unevaluated matrix titles from showing up in results without side effects, so just go back to the original strategy of using `if`.

Closes #218