### PR TITLE
Remove workaround for bug triggered by Android environment variable

### DIFF
--- a/.github/workflows/scripts/install-and-build-with-sdk.sh
+++ b/.github/workflows/scripts/install-and-build-with-sdk.sh
@@ -797,11 +797,6 @@ build() {
 
             log "Running: $build_command"
 
-            # clear the ANDROID_NDK_ROOT environment variable if it is set
-            # due to https://github.com/swiftlang/swift-driver/pull/1879
-            # otherwise build error: missing required module 'SwiftAndroid'
-            export ANDROID_NDK_ROOT=""
-
             if eval "$build_command"; then
                 log "✅ Swift build with Android Swift SDK completed successfully"
             else


### PR DESCRIPTION
We had to unset this common Android env var to work around the compiler bug, but it should be fixed in the compiler now.