### PR TITLE
Make CONTRIBUTORS.txt optional in license headers

### DIFF
--- a/.github/workflows/scripts/check-license-header.sh
+++ b/.github/workflows/scripts/check-license-header.sh
@@ -122,10 +122,20 @@ while IFS= read -r file_path; do
     | sed -E -e 's/20[12][0123456789] ?[-–] ?20[12][0123456789]/YEARS/' -e 's/20[12][0123456789]/YEARS/' \
   )
 
-  if ! diff -u \
+  if ! diff_output=$(diff -u \
     --label "Expected header" <(echo "${expected_file_header}") \
-    --label "${file_path}" <(echo "${normalized_file_header}")
+    --label "${file_path}" <(echo "${normalized_file_header}"))
   then
+    expected_file_header_without_contributors=$(echo "${expected_file_header}" | sed '/CONTRIBUTORS\.txt/d')
+    normalized_file_header_without_contributors=$(echo "${normalized_file_header}" | sed '/CONTRIBUTORS\.txt/d')
+    if [ "${expected_file_header}" != "${expected_file_header_without_contributors}" ] \
+      && diff -u \
+        --label "Expected header" <(echo "${expected_file_header_without_contributors}") \
+        --label "${file_path}" <(echo "${normalized_file_header_without_contributors}") > /dev/null
+    then
+      continue
+    fi
+    echo "${diff_output}"
     paths_with_missing_license+=("${file_path} ")
   fi
 done <<< "$file_paths"

--- a/tests/check-license-header.sh
+++ b/tests/check-license-header.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+##
+##===----------------------------------------------------------------------===##
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+tmpdir=$(mktemp -d)
+trap 'rm -rf "${tmpdir}"' EXIT
+
+mkdir -p "${tmpdir}/.github/workflows/scripts"
+cp "${repo_root}/.github/workflows/scripts/check-license-header.sh" "${tmpdir}/.github/workflows/scripts/check-license-header.sh"
+
+cd "${tmpdir}"
+git init -q
+
+cat > WithContributors.swift <<'EOF'
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Logging API open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Logging API project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Logging API project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+EOF
+
+cat > WithoutContributors.swift <<'EOF'
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Logging API open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift Logging API project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+EOF
+
+git add WithContributors.swift WithoutContributors.swift
+
+PROJECT_NAME="Swift Logging API" .github/workflows/scripts/check-license-header.sh


### PR DESCRIPTION
## Summary

https://github.com/swiftlang/github-workflows/issues/267

Update the shared license header check so source headers can omit the
`CONTRIBUTORS.txt` line.

Some Swift repositories have removed `CONTRIBUTORS.txt`, so requiring this line
in every source header leaves stale references behind. The check now continues
to accept existing headers that include the line, but also accepts headers where
the line has been removed.

## Details

The checker still validates the full expected header first. If that comparison
fails, it retries after removing any `CONTRIBUTORS.txt` line from both the
expected header and the file header.

This keeps compatibility for repositories that still include the line while
allowing repositories that have removed `CONTRIBUTORS.txt` to update their
headers.

## Testing

Added `tests/check-license-header.sh`, which creates a temporary git repo with
two Swift files:

- one header with the `CONTRIBUTORS.txt` line
- one header without the `CONTRIBUTORS.txt` line

Both are checked using the real license header script.

Manually verified with:

```bash
tests/check-license-header.sh
shellcheck tests/check-license-header.sh .github/workflows/scripts/check-license-header.sh
PROJECT_NAME=Swift.org .github/workflows/scripts/check-license-header.sh
