### PR TITLE
extract PR Dependency Check for github-workflows into its own file

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,22 +2,15 @@ name: Pull request
 
 permissions:
   contents: read
-  issues: read
-  pull-requests: read
 
 on:
   pull_request:
-    types: [opened, edited, reopened, labeled, unlabeled, synchronize]
+    types: [opened, reopened, synchronize]
 
 jobs:
-  github_actiion_pr_dependency_check:
-    name: GitHub Action Dependency Check
-    uses: ./.github/workflows/github_actions_dependencies.yml
-
   tests_with_docker_embedded_swift:
     name: Test Embedded Swift SDKs
     uses: ./.github/workflows/swift_package_test.yml
-    if: ${{ github.event_name == 'opened' || github.event_name == 'reopened' || github.event_name == 'synchronize' }}
     with:
       # Wasm
       enable_linux_checks: false
@@ -30,7 +23,6 @@ jobs:
   tests_with_docker:
     name: Test with Docker
     uses: ./.github/workflows/swift_package_test.yml
-    if: ${{ github.event_name == 'opened' || github.event_name == 'reopened' || github.event_name == 'synchronize' }}
     with:
       # Linux
       linux_os_versions: '["jammy", "rhel-ubi9", "amazonlinux2"]'
@@ -54,7 +46,6 @@ jobs:
   tests_without_docker:
     name: Test without Docker
     uses: ./.github/workflows/swift_package_test.yml
-    if: ${{ github.event_name == 'opened' || github.event_name == 'reopened' || github.event_name == 'synchronize' }}
     with:
       # Skip Linux which doesn't currently support docker-less workflow
       enable_linux_checks: false
@@ -76,7 +67,6 @@ jobs:
   tests_macos:
     name: Test
     uses: ./.github/workflows/swift_package_test.yml
-    if: ${{ github.event_name == 'opened' || github.event_name == 'reopened' || github.event_name == 'synchronize' }}
     with:
       enable_linux_checks: false
       enable_windows_checks: false
@@ -89,7 +79,6 @@ jobs:
   build_tests_ios:
     name: Build iOS Tests
     uses: ./.github/workflows/swift_package_test.yml
-    if: ${{ github.event_name == 'opened' || github.event_name == 'reopened' || github.event_name == 'synchronize' }}
     with:
       enable_linux_checks: false
       enable_windows_checks: false
@@ -102,7 +91,6 @@ jobs:
   soundness:
     name: Soundness
     uses: ./.github/workflows/soundness.yml
-    if: ${{ github.event_name == 'opened' || github.event_name == 'reopened' || github.event_name == 'synchronize' }}
     with:
       api_breakage_check_enabled: false
       license_header_check_project_name: "Swift.org"

--- a/.github/workflows/pull_request_dependency_check.yml
+++ b/.github/workflows/pull_request_dependency_check.yml
@@ -1,0 +1,14 @@
+name: PR Dependency Check
+
+permissions:
+  issues: read
+  pull-requests: read
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, labeled, unlabeled, synchronize]
+
+jobs:
+  github_actiion_pr_dependency_check:
+    name: GitHub Action Dependency Check
+    uses: ./.github/workflows/github_actions_dependencies.yml


### PR DESCRIPTION
This is a fix for https://github.com/swiftlang/github-workflows/pull/233/

Because the Pr dependency check has different triggers, extract it into it's own file for this repository that way we can use the proper triggering syntax when PR's are opened