### PR TITLE
[freebsd] cd into the proper dir to run package test

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -63,6 +63,8 @@ jobs:
       windows_os_versions: '["windows-2022", "windows-11-arm"]'
       # FreeBSD
       enable_freebsd_checks: true
+      freebsd_pre_build_command: |
+        cd tests/TestPackage
 
   tests_macos:
     name: Test


### PR DESCRIPTION
Fix the workflow action 

```
  Swift version 6.3-dev (LLVM 972b62858355d07, Swift 3f8c798cfe25bbb)
  Target: x86_64-unknown-freebsd14.3
  Build config: +assertions
  error: Could not find Package.swift in this directory or any of its parent directories.
```