### PR TITLE
Extend ignore list in flake8 config

### DIFF
--- a/.github/workflows/configs/.flake8
+++ b/.github/workflows/configs/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 
-ignore =
+extend-ignore =
     # These are needed to make our license headers pass the linting
     E265,
     E266,


### PR DESCRIPTION
flake8 disables a number of checks by default, e.g. W503 [1] and W504 [2], which are conflicting checks and are both not violations of the PEP8 standard. In the flake8 config, the `ignore` key overrides the default ignore list, leading to these issues being raised in CI. The `extend-ignore` key extends the default ignore list instead, allowing these issues to correctly remain suppressed.

[1]: https://www.flake8rules.com/rules/W503.html
[2]: https://www.flake8rules.com/rules/W504.html