### PR TITLE
docs: add missing closing backtick in error message

### DIFF
--- a/.github/workflows/scripts/cross-pr-checkout.swift
+++ b/.github/workflows/scripts/cross-pr-checkout.swift
@@ -186,7 +186,7 @@ func main() async throws {
     throw GenericError(
       """
       Expected two arguments:
-      - Repository name, eg. `swiftlang/swift-syntax
+      - Repository name, eg. `swiftlang/swift-syntax`
       - PR number
       """
     )


### PR DESCRIPTION
## Summary

Add missing closing backtick in `cross-pr-checkout.swift` error message:

- Line 189: `` `swiftlang/swift-syntax `` → `` `swiftlang/swift-syntax` ``

The two other references to this example (lines 114 and 141) already have the closing backtick. This corrects the formatting in the usage error message.