### PR TITLE
Add a build verdict job

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -132,3 +132,33 @@ jobs:
       shell_check_enabled: false
       yamllint_check_enabled: false
       python_lint_check_enabled: false
+
+  build-verdict:
+    name: Build Verdict
+    needs:
+      - tests_with_docker_embedded_swift
+      - tests_with_docker
+      - tests_without_docker
+      - tests_macos
+      - build_tests_ios
+      - soundness
+      - proposal_validation
+      - soundness-docs
+    runs-on: ubuntu-latest
+    if: always()  # Runs even if previous jobs fail so it can evaluate them
+    steps:
+      - name: Install required tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends coreutils jq
+      - name: Check upstream job statuses
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failed=$(printf '%s' "$NEEDS_JSON" | jq -r 'to_entries | map(select(.value.result != "success")) | .[] | "\(.key): \(.value.result)"')
+          if [ -n "$failed" ]; then
+            echo "The following required jobs did not succeed:"
+            printf '%s\n' "$failed"
+            exit 1
+          fi
+          echo "All required jobs passed successfully!"


### PR DESCRIPTION
Add a build verdict job that will fail when any dependent workflow fails. The workflow also emits, on the console, all required job names that failed.

Depends on #290