### PR TITLE
Update default Xcode versions in workflow to Xcode 27 Beta 2

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -9,7 +9,7 @@ on:
       macos_xcode_versions:
         type: string
         description: "Xcode version list (JSON)"
-        default: "[\"16.4\", \"26.3\", \"26.4\"]"
+        default: "[\"16.4\", \"26.3\", \"26.4\", \"27.b2\"]"
       macos_exclude_xcode_versions:
         type: string
         description: "Exclude Xcode version list (JSON)"


### PR DESCRIPTION
Added Xcode version '27.b2' to the default list.