### PR TITLE
Update actions/checkout to v7

### DIFF
--- a/.github/workflows/create_automerge_pr.yml
+++ b/.github/workflows/create_automerge_pr.yml
@@ -69,7 +69,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Check if there are commits to merge

--- a/.github/workflows/performance_test.yml
+++ b/.github/workflows/performance_test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install libjemalloc-dev
         run: apt-get update && apt-get install -y libjemalloc-dev
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Mark the workspace as safe

--- a/.github/workflows/proposal_validation.yml
+++ b/.github/workflows/proposal_validation.yml
@@ -23,7 +23,7 @@ jobs:
       RESOLVED_PR_NUMBER: ${{ case(inputs.workflow_test_enabled, '3331', github.event.number) }}
     steps:
       - name: Checkout swiftlang/swift-evolution-metadata-extractor (main)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: swiftlang/swift-evolution-metadata-extractor
           ref: main

--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -138,7 +138,7 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # This is set to true since swift package diagnose-api-breaking-changes is
           # cloning the repo again and without it being set to true this job won't work for
@@ -182,13 +182,13 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: true
       - name: Checkout swiftlang/github-workflows repository
         if: ${{ github.repository != 'swiftlang/github-workflows' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: swiftlang/github-workflows
           path: github-workflows
@@ -226,13 +226,13 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: true
       - name: Checkout swiftlang/github-workflows repository
         if: ${{ github.repository != 'swiftlang/github-workflows' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: swiftlang/github-workflows
           path: github-workflows
@@ -277,13 +277,13 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: true
       - name: Checkout swiftlang/github-workflows repository
         if: ${{ github.repository != 'swiftlang/github-workflows' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: swiftlang/github-workflows
           path: github-workflows
@@ -308,13 +308,13 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: true
       - name: Checkout swiftlang/github-workflows repository
         if: ${{ github.repository != 'swiftlang/github-workflows' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: swiftlang/github-workflows
           path: github-workflows
@@ -339,13 +339,13 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: true
       - name: Checkout swiftlang/github-workflows repository
         if: ${{ github.repository != 'swiftlang/github-workflows' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: swiftlang/github-workflows
           path: github-workflows
@@ -371,13 +371,13 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: true
       - name: Checkout swiftlang/github-workflows repository
         if: ${{ github.repository != 'swiftlang/github-workflows' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: swiftlang/github-workflows
           path: github-workflows
@@ -408,7 +408,7 @@ jobs:
       - name: Install git
         run: which git || (apt -q update && apt -yq install git)
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: true
@@ -427,13 +427,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: true
       - name: Checkout swiftlang/github-workflows repository
         if: ${{ github.repository != 'swiftlang/github-workflows' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: swiftlang/github-workflows
           path: github-workflows
@@ -464,13 +464,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: true
       - name: Checkout swiftlang/github-workflows repository
         if: ${{ github.repository != 'swiftlang/github-workflows' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: swiftlang/github-workflows
           path: github-workflows

--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -285,7 +285,7 @@ jobs:
           - ${{ fromJson(inputs.macos_exclude_xcode_versions) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Provide token
         if: ${{ inputs.needs_token }}
         run: |
@@ -327,7 +327,7 @@ jobs:
           - ${{ fromJson(inputs.ios_host_exclude_xcode_versions || inputs.macos_exclude_xcode_versions) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Provide token
         if: ${{ inputs.needs_token }}
         run: |
@@ -387,14 +387,14 @@ jobs:
       - name: Clang version
         run: clang --version
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         if: ${{ matrix.os_version != 'amazonlinux2' }}
       - name: Checkout repository
         uses: actions/checkout@v1
         if: ${{ matrix.os_version == 'amazonlinux2' }}
       - name: Checkout swiftlang/github-workflows repository
         if: ${{ matrix.os_version != 'amazonlinux2' && github.repository != 'swiftlang/github-workflows' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: swiftlang/github-workflows
           path: github-workflows
@@ -471,14 +471,14 @@ jobs:
       - name: Clang version
         run: clang --version
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         if: ${{ matrix.os_version != 'amazonlinux2' }}
       - name: Checkout repository
         uses: actions/checkout@v1
         if: ${{ matrix.os_version == 'amazonlinux2' }}
       - name: Checkout swiftlang/github-workflows repository
         if: ${{ matrix.os_version != 'amazonlinux2' && github.repository != 'swiftlang/github-workflows' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: swiftlang/github-workflows
           path: github-workflows
@@ -540,14 +540,14 @@ jobs:
       - name: Clang version
         run: clang --version
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         if: ${{ matrix.os_version != 'amazonlinux2' }}
       - name: Checkout repository
         uses: actions/checkout@v1
         if: ${{ matrix.os_version == 'amazonlinux2' }}
       - name: Checkout swiftlang/github-workflows repository
         if: ${{ matrix.os_version != 'amazonlinux2' && github.repository != 'swiftlang/github-workflows' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: swiftlang/github-workflows
           path: github-workflows
@@ -609,14 +609,14 @@ jobs:
       - name: Clang version
         run: clang --version
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         if: ${{ matrix.os_version != 'amazonlinux2' }}
       - name: Checkout repository
         uses: actions/checkout@v1
         if: ${{ matrix.os_version == 'amazonlinux2' }}
       - name: Checkout swiftlang/github-workflows repository
         if: ${{ matrix.os_version != 'amazonlinux2' && github.repository != 'swiftlang/github-workflows' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: swiftlang/github-workflows
           path: github-workflows
@@ -679,9 +679,9 @@ jobs:
           sudo rm /usr/local/lib/libsourcekitdInProc.so
           sudo rm -r /usr/share/swift
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Checkout swiftlang/github-workflows repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: swiftlang/github-workflows
           path: github-workflows
@@ -750,10 +750,10 @@ jobs:
           - ${{ fromJson(inputs.windows_exclude_swift_versions) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Checkout swiftlang/github-workflows repository
         if: ${{ github.repository != 'swiftlang/github-workflows' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: swiftlang/github-workflows
           path: github-workflows
@@ -924,10 +924,10 @@ jobs:
             runner: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Checkout swiftlang/github-workflows repository
         if: ${{ github.repository != 'swiftlang/github-workflows' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: swiftlang/github-workflows
           path: github-workflows


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` from `v4`/`v6` to `v7` across all workflow files
- `v1` references (used for `amazonlinux2` compatibility) are left unchanged

## Files changed
- `.github/workflows/soundness.yml`
- `.github/workflows/swift_package_test.yml`
- `.github/workflows/create_automerge_pr.yml`
- `.github/workflows/performance_test.yml`
- `.github/workflows/proposal_validation.yml`