### PR TITLE
Add GITHUB_TOKEN env variable for use by extraction tool

### DIFF
--- a/.github/workflows/proposal_validation.yml
+++ b/.github/workflows/proposal_validation.yml
@@ -21,6 +21,7 @@ jobs:
     timeout-minutes: 10
     env:
       RESOLVED_PR_NUMBER: ${{ case(inputs.workflow_test_enabled, '3331', github.event.number) }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout swiftlang/swift-evolution-metadata-extractor (main)
         uses: actions/checkout@v6


### PR DESCRIPTION
The proposal validation workflow and the extractor tool that performs the validation uses GitHub APIs which are rate limited.

This PR exposes the GitHub token generated per run of the workflow as an environment variable to ensure the extractor tool has access to the token and much higher API rate limits.