### PR TITLE
Map Amazon Linux 2023 to amazonlinux2023 toolchain infix

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,7 +25,9 @@ jobs:
     uses: ./.github/workflows/swift_package_test.yml
     with:
       # Linux
-      linux_os_versions: '["jammy", "rhel-ubi9"]'
+      linux_os_versions: '["jammy", "rhel-ubi9", "amazonlinux2023"]'
+      # Amazon Linux 2023 images are only available for Swift 6.3 and later.
+      linux_exclude_swift_versions: '[{"swift_version": "5.9", "os_version": "amazonlinux2023"}, {"swift_version": "5.10", "os_version": "amazonlinux2023"}, {"swift_version": "6.0", "os_version": "amazonlinux2023"}, {"swift_version": "6.1", "os_version": "amazonlinux2023"}, {"swift_version": "6.2", "os_version": "amazonlinux2023"}]'
       linux_host_archs: '["x86_64", "aarch64"]'
       linux_build_command: |
         cd tests/TestPackage

--- a/.github/workflows/scripts/install-and-build-with-sdk.sh
+++ b/.github/workflows/scripts/install-and-build-with-sdk.sh
@@ -485,6 +485,9 @@ initialize_os_info() {
     elif [[ "$os_id" == "amzn" && "$version_id" == "2" ]]; then
         OS_NAME="amazonlinux2"
         OS_NAME_NO_DOT="amazonlinux2"
+    elif [[ "$os_id" == "amzn" && "$version_id" == "2023" ]]; then
+        OS_NAME="amazonlinux2023"
+        OS_NAME_NO_DOT="amazonlinux2023"
     else
         # Ubuntu, Debian, Fedora
         OS_NAME="${os_id}${version_id}"


### PR DESCRIPTION
## Problem

When running on Amazon Linux 2023 images, the SDK install script fails with:

```
** Detected OS from /etc/os-release: amzn2023
** Using OS name: amzn2023
** Downloading Swift toolchain: swift-DEVELOPMENT-SNAPSHOT-2026-06-30-a
** Toolchain not found: swift-DEVELOPMENT-SNAPSHOT-2026-06-30-a-amzn2023-aarch64.tar.gz
** Exiting workflow...
```

Amazon Linux 2023 reports `ID=amzn` and `VERSION_ID=2023` in `/etc/os-release`. This combination fell through to the generic `else` branch in `initialize_os_info()`, producing the OS name `amzn2023`. But swift.org publishes the toolchain under the `amazonlinux2023` infix, so the constructed download URL was invalid.

## Fix

Special-case `amzn`+`2023` to map to `amazonlinux2023`, matching the existing handling for `amzn`+`2` → `amazonlinux2`.