### PR TITLE
update check_docs.sh to support ADDITIONAL_DOCC_ARGUMENTS

### DIFF
--- a/.github/workflows/scripts/check-docs.sh
+++ b/.github/workflows/scripts/check-docs.sh
@@ -11,7 +11,7 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-set -euo pipefail
+set -xeuo pipefail
 
 log() { printf -- "** %s\n" "$*" >&2; }
 error() { printf -- "** ERROR: %s\n" "$*" >&2; }
@@ -41,7 +41,7 @@ is_known_option() {
 }
 
 analyze_flag="--analyze"
-additional_docc_arguments=""
+additional_docc_arguments="${ADDITIONAL_DOCC_ARGUMENTS:-}"
 docs_targets=""
 while [[ $# -gt 0 ]]; do
   case "$1" in


### PR DESCRIPTION
In version 0.0.11, the ADDITIONAL_DOCC_ARGUMENTS environment variable is supported by the check-docs.sh script.  Version 0.0.12 modified the check-docs.sh was updated in version 0.0.12 to not depend on the environment variable.  However, this caused a regression for worlflows that were still using 0.0.11 as the defined environment variable was no longer being used.

Update the check-docs.sh script to default the additional_docc_argument to the environment variable.