### PR TITLE
Fix documentation check building every target N times

### DIFF
--- a/.github/workflows/scripts/check-docs.sh
+++ b/.github/workflows/scripts/check-docs.sh
@@ -94,7 +94,7 @@ if ! command -v yq &> /dev/null; then
 fi
 
 if [ -z "${docs_targets}" ] ; then
-  docs_targets=$(yq -r ".builder.configs[] | select(.documentation_targets[] != \"\") | .documentation_targets[]" .spi.yml)
+  docs_targets=$(yq -r ".builder.configs[].documentation_targets[] | select(. != \"\")" .spi.yml)
 fi
 
 package_files=$(find . -maxdepth 1 -name 'Package*.swift')


### PR DESCRIPTION
The `Documentation check` soundness job appears to hang and is eventually cancelled at the 20-minute `timeout-minutes` limit (`context canceled` / `The operation was canceled.`). It isn't actually looping forever — it's building **every documentation target ~N times**, where N is the number of targets.

Observed in swift-syntax CI: a `.spi.yml` with 17 documentation targets produced a `docs_targets` list of **272 entries** (17 × 16), so `check-docs.sh` invoked `swift package plugin generate-documentation` hundreds of times and never finished within the timeout.

`check-docs.sh` reads targets with:

```bash
docs_targets=$(yq -r ".builder.configs[] | select(.documentation_targets[] != \"\") | .documentation_targets[]" .spi.yml)
```

The condition inside `select(...)`, `.documentation_targets[] != ""`, evaluates `.documentation_targets[]` as a **stream** of N booleans (one per target). `select` re-emits its input config once for **each** truthy value, so a single config is emitted N times, and the trailing `.documentation_targets[]` then expands each copy back into N targets → an N×N list.

Introduced in #282, which rewrote the previously-correct `.builder.configs[].documentation_targets[]`.
