### PR TITLE
Group dependabot updates for GHA workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Currently, Dependabot is configured such that it will open one PR per workflow when a new version is released. For repositories that define multiple workflows, this can be noisy. Dependabot provides the ability to group multiple updates in a package ecosystem into a single PR [1]. This patch updates Dependabot to use a group for the `github-actions` package ecosystem.

[1]: https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates#grouping-related-dependencies-together