### PR TITLE
Run linux pre-build commands as part of the API breakage step

### DIFF
--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -150,16 +150,14 @@ jobs:
       - name: Mark the workspace as safe
         # https://github.com/actions/checkout/issues/766
         run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
-      - name: Pre-build
-        if: ${{ inputs.linux_pre_build_command }}
-        # zizmor: ignore[template-injection]
-        run: ${{ inputs.linux_pre_build_command }}
       - name: Run API breakage check
         shell: bash
         env:
           API_BREAKAGE_CHECK_BASELINE: ${{ inputs.api_breakage_check_baseline }}
           API_BREAKAGE_CHECK_ALLOWLIST_PATH: ${{ inputs.api_breakage_check_allowlist_path }}
+        # zizmor: ignore[template-injection]
         run: |
+          ${{ inputs.linux_pre_build_command }}
           if [[ -z "${API_BREAKAGE_CHECK_BASELINE}" ]]; then
             git fetch ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} ${GITHUB_BASE_REF}:pull-base-ref
             BASELINE_REF='pull-base-ref'


### PR DESCRIPTION
Environment variables set in pre-build commands do not persist into the API breakage step. This change moves the pre-build command execution into the API-breakage check. Similar to 6078937, which did this for the docs check.