### PR TITLE
Make Windows CI fail when command fails to launch

### DIFF
--- a/.github/workflows/swift_package_test.yml
+++ b/.github/workflows/swift_package_test.yml
@@ -920,10 +920,17 @@ jobs:
 
           # Run the command following `Invoke-Program`.
           # If that command returns a non-zero exit code, return the same exit code from this script.
+          # When there is no exit code (e.g. program failed to launch), we fall back to $?.
           function Invoke-Program($Executable) {
+            $global:LASTEXITCODE = $null
             & $Executable @args
-            if ($LastExitCode -ne 0) {
-              exit $LastExitCode
+            $ok = $?
+            if ($null -eq $LASTEXITCODE) {
+              if (-not $ok) {
+                exit 1
+              }
+            } elseif ($LASTEXITCODE -ne 0) {
+              exit $LASTEXITCODE
             }
           }
           Invoke-Program swift --version


### PR DESCRIPTION
Invoke-Program used `exit $LastExitCode`, but when a native command fails to launch (e.g. a broken toolchain) no exit code is set, leaving $LASTEXITCODE as $null. `exit $null` exits 0, so the container reports success and the step is green despite the failure (like [this occurence](https://github.com/swiftlang/swift-package-manager/actions/runs/29766644951/job/88434456907?pr=10308) in [swiftlang/swift-package-manager](https://github.com/swiftlang/swift-package-manager)).

Reset `$LASTEXITCODE` before each call and fall back to $? when no exit code is produced, so launch failures now fail properly.